### PR TITLE
Media Picker: fix layout issues

### DIFF
--- a/Vector/ViewController/MediaPickerViewController.xib
+++ b/Vector/ViewController/MediaPickerViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
     </dependencies>
     <objects>
@@ -41,33 +41,45 @@
                                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                 </view>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PXk-ZD-TYS" userLabel="Camera Switch Button">
-                                    <rect key="frame" x="548" y="35" width="29" height="22"/>
+                                    <rect key="frame" x="543" y="30" width="39" height="32"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="22" id="5IK-zA-C0Z"/>
-                                        <constraint firstAttribute="width" constant="29" id="JWE-xq-eRq"/>
+                                        <constraint firstAttribute="height" constant="32" id="5IK-zA-C0Z"/>
+                                        <constraint firstAttribute="width" constant="39" id="JWE-xq-eRq"/>
                                     </constraints>
-                                    <state key="normal" image="camera_switch.png">
+                                    <state key="normal">
                                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                     </state>
-                                    <state key="highlighted" image="camera_switch.png"/>
                                     <connections>
                                         <action selector="onButtonPressed:" destination="-1" eventType="touchUpInside" id="xHg-kl-L3w"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sO8-Ds-mXZ" userLabel="Close Button">
-                                    <rect key="frame" x="23" y="35" width="22" height="22"/>
+                                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="camera_switch.png" translatesAutoresizingMaskIntoConstraints="NO" id="etc-h5-0u2">
+                                    <rect key="frame" x="548" y="35" width="29" height="22"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="22" id="Rrv-zB-kX4"/>
-                                        <constraint firstAttribute="height" constant="22" id="nXZ-ee-z3I"/>
+                                        <constraint firstAttribute="width" constant="29" id="Mci-PP-bNY"/>
+                                        <constraint firstAttribute="height" constant="22" id="cqi-nf-MLe"/>
                                     </constraints>
-                                    <state key="normal" image="remove_icon.png">
+                                </imageView>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sO8-Ds-mXZ" userLabel="Close Button">
+                                    <rect key="frame" x="18" y="30" width="32" height="32"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="32" id="Rrv-zB-kX4"/>
+                                        <constraint firstAttribute="height" constant="32" id="nXZ-ee-z3I"/>
+                                    </constraints>
+                                    <state key="normal">
                                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                     </state>
-                                    <state key="highlighted" image="remove_icon.png"/>
                                     <connections>
                                         <action selector="onButtonPressed:" destination="-1" eventType="touchUpInside" id="nvH-aw-ZJK"/>
                                     </connections>
                                 </button>
+                                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="remove_icon.png" translatesAutoresizingMaskIntoConstraints="NO" id="VA2-Cu-dX6">
+                                    <rect key="frame" x="23" y="35" width="22" height="22"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="22" id="AVO-AA-HaQ"/>
+                                        <constraint firstAttribute="width" constant="22" id="UST-cV-kEd"/>
+                                    </constraints>
+                                </imageView>
                                 <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="dxP-iB-dWk" userLabel="Camera Activity Indicator">
                                     <rect key="frame" x="290" y="430" width="20" height="20"/>
                                 </activityIndicatorView>
@@ -87,18 +99,22 @@
                                 </button>
                             </subviews>
                             <constraints>
-                                <constraint firstItem="PXk-ZD-TYS" firstAttribute="top" secondItem="cE0-0g-Su5" secondAttribute="top" constant="35" id="3bv-hT-POE"/>
+                                <constraint firstItem="etc-h5-0u2" firstAttribute="centerX" secondItem="PXk-ZD-TYS" secondAttribute="centerX" id="1Kl-Hi-rvU"/>
+                                <constraint firstItem="PXk-ZD-TYS" firstAttribute="top" secondItem="cE0-0g-Su5" secondAttribute="top" constant="30" id="3bv-hT-POE"/>
                                 <constraint firstAttribute="trailing" secondItem="w7z-f3-kdT" secondAttribute="trailing" id="5lY-ez-A5W"/>
                                 <constraint firstAttribute="bottom" secondItem="uRG-b0-CjY" secondAttribute="bottom" constant="30" id="F15-CU-duW"/>
+                                <constraint firstItem="VA2-Cu-dX6" firstAttribute="centerY" secondItem="sO8-Ds-mXZ" secondAttribute="centerY" id="Fze-aW-Jg3"/>
                                 <constraint firstAttribute="bottom" secondItem="w7z-f3-kdT" secondAttribute="bottom" id="Odc-BN-d37"/>
                                 <constraint firstAttribute="width" secondItem="cE0-0g-Su5" secondAttribute="height" multiplier="15:22" id="QDd-Tq-4zL"/>
+                                <constraint firstItem="VA2-Cu-dX6" firstAttribute="centerX" secondItem="sO8-Ds-mXZ" secondAttribute="centerX" id="Xmg-sf-k4n"/>
+                                <constraint firstItem="etc-h5-0u2" firstAttribute="centerY" secondItem="PXk-ZD-TYS" secondAttribute="centerY" id="cW6-ue-5Vb"/>
                                 <constraint firstItem="w7z-f3-kdT" firstAttribute="leading" secondItem="cE0-0g-Su5" secondAttribute="leading" id="eH4-0j-WXi"/>
                                 <constraint firstItem="w7z-f3-kdT" firstAttribute="top" secondItem="cE0-0g-Su5" secondAttribute="top" id="kXk-s5-NTi"/>
                                 <constraint firstItem="dxP-iB-dWk" firstAttribute="centerY" secondItem="cE0-0g-Su5" secondAttribute="centerY" id="lut-Up-d2d"/>
-                                <constraint firstAttribute="trailing" secondItem="PXk-ZD-TYS" secondAttribute="trailing" constant="23" id="nlx-eq-jfm"/>
-                                <constraint firstItem="sO8-Ds-mXZ" firstAttribute="top" secondItem="cE0-0g-Su5" secondAttribute="top" constant="35" id="oLB-32-Cmq"/>
+                                <constraint firstAttribute="trailing" secondItem="PXk-ZD-TYS" secondAttribute="trailing" constant="18" id="nlx-eq-jfm"/>
+                                <constraint firstItem="sO8-Ds-mXZ" firstAttribute="top" secondItem="cE0-0g-Su5" secondAttribute="top" constant="30" id="oLB-32-Cmq"/>
                                 <constraint firstAttribute="centerX" secondItem="uRG-b0-CjY" secondAttribute="centerX" id="sca-zF-zuj"/>
-                                <constraint firstItem="sO8-Ds-mXZ" firstAttribute="leading" secondItem="cE0-0g-Su5" secondAttribute="leading" constant="23" id="tCv-ru-PZS"/>
+                                <constraint firstItem="sO8-Ds-mXZ" firstAttribute="leading" secondItem="cE0-0g-Su5" secondAttribute="leading" constant="18" id="tCv-ru-PZS"/>
                                 <constraint firstItem="dxP-iB-dWk" firstAttribute="centerX" secondItem="cE0-0g-Su5" secondAttribute="centerX" id="xNd-lI-T6h"/>
                             </constraints>
                         </view>

--- a/Vector/Views/MediaAlbum/MediaAlbumTableCell.xib
+++ b/Vector/Views/MediaAlbum/MediaAlbumTableCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -14,7 +14,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="567" height="73"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6Kl-sK-vhs">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6Kl-sK-vhs">
                         <rect key="frame" x="0.0" y="0.0" width="73" height="73"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="73" id="HEG-jX-hiD"/>


### PR DESCRIPTION
- Enlarge the touch area of the 'Close' and 'Camera switch' button.
- Crop album thumbnail to fit the display box.
- Remove the thumbnail of 'Recently Deleted' album.
- Fix simultaneous asset selection. Only the first selected asset is considered.
- Fix multiple selfies capture. Only one selfie is captured at once.