### PR TITLE
Universal link: Enabled universal links declared at vector.im.

### DIFF
--- a/Vector.xcodeproj/project.pbxproj
+++ b/Vector.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		32D200821C15C56A00A4E396 /* search_bg@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "search_bg@3x.png"; sourceTree = "<group>"; };
 		32D200861C16C2B100A4E396 /* HomeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HomeViewController.h; sourceTree = "<group>"; };
 		32D200871C16C2B100A4E396 /* HomeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HomeViewController.m; sourceTree = "<group>"; };
+		32F2ABFC1CB5694B00BF205F /* Vector.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Vector.entitlements; sourceTree = "<group>"; };
 		32F2E6191C230D4D003BDEA5 /* PublicRoomsDirectoryDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PublicRoomsDirectoryDataSource.h; sourceTree = "<group>"; };
 		32F2E61A1C230D4D003BDEA5 /* PublicRoomsDirectoryDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PublicRoomsDirectoryDataSource.m; sourceTree = "<group>"; };
 		435C7E1A9BC3DE28D526540F /* Pods-Vector.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Vector.release.xcconfig"; path = "Pods/Target Support Files/Pods-Vector/Pods-Vector.release.xcconfig"; sourceTree = "<group>"; };
@@ -812,6 +813,7 @@
 		F094A9A41B78D8F000B1FBBF /* Vector */ = {
 			isa = PBXGroup;
 			children = (
+				32F2ABFC1CB5694B00BF205F /* Vector.entitlements */,
 				F094AA071B78E42600B1FBBF /* API */,
 				F094AA0A1B78E42600B1FBBF /* Assets */,
 				F0C34CB51C17145F00C36F09 /* Categories */,
@@ -1571,6 +1573,7 @@
 			baseConfigurationReference = 11865E69C29698A4179E1F3F /* Pods-Vector.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Vector/Vector.entitlements;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Vector/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -1585,6 +1588,7 @@
 			baseConfigurationReference = 435C7E1A9BC3DE28D526540F /* Pods-Vector.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Vector/Vector.entitlements;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Vector/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;

--- a/Vector/AppDelegate.h
+++ b/Vector/AppDelegate.h
@@ -81,7 +81,7 @@
 
 #pragma mark - Matrix Room handling
 
-- (void)showRoom:(NSString*)roomId withMatrixSession:(MXSession*)mxSession;
+- (void)showRoom:(NSString*)roomId andEventId:(NSString*)eventId withMatrixSession:(MXSession*)mxSession;
 
 // Reopen an existing private OneToOne room with this userId or creates a new one (if it doesn't exist)
 - (void)startPrivateOneToOneRoomWithUserId:(NSString*)userId completion:(void (^)(void))completion;

--- a/Vector/AppDelegate.m
+++ b/Vector/AppDelegate.m
@@ -423,6 +423,16 @@
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
+{
+    if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb])
+    {
+        NSURL *webURL = userActivity.webpageURL;
+        NSLog(@"%@", webURL.absoluteString);
+    }
+    return YES;
+}
+
 #pragma mark - Application layout handling
 
 - (void)restoreInitialDisplay:(void (^)())completion

--- a/Vector/Vector.entitlements
+++ b/Vector/Vector.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:vector.im</string>
+	</array>
+</dict>
+</plist>

--- a/Vector/ViewController/DirectoryViewController.m
+++ b/Vector/ViewController/DirectoryViewController.m
@@ -125,7 +125,7 @@
 - (void)openRoomWithId:(NSString*)roomId inMatrixSession:(MXSession*)mxSession
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[AppDelegate theDelegate].homeViewController selectRoomWithId:roomId inMatrixSession:mxSession];
+        [[AppDelegate theDelegate].homeViewController selectRoomWithId:roomId andEventId:nil inMatrixSession:mxSession];
     });
 }
 

--- a/Vector/ViewController/HomeViewController.h
+++ b/Vector/ViewController/HomeViewController.h
@@ -31,6 +31,7 @@
 // References on the currently selected room and its view controller
 @property (nonatomic, readonly) RoomViewController *currentRoomViewController;
 @property (nonatomic, readonly) NSString  *selectedRoomId;
+@property (nonatomic, readonly) NSString  *selectedEventId;
 @property (nonatomic, readonly) MXSession *selectedRoomSession;
 
 
@@ -50,9 +51,10 @@
  Open the room with the provided identifier in a specific matrix session.
 
  @param roomId the room identifier.
+ @param eventId if not nil, the room will be opened on this event.
  @param mxSession the matrix session in which the room should be available.
  */
-- (void)selectRoomWithId:(NSString*)roomId inMatrixSession:(MXSession*)mxSession;
+- (void)selectRoomWithId:(NSString*)roomId andEventId:(NSString*)eventId inMatrixSession:(MXSession*)mxSession;
 
 /**
  Close the current selected room (if any)

--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -391,7 +391,7 @@
             [self.mainSession joinRoom:roomAlias success:^(MXRoom *room)
              {
                  // Show the room
-                 [[AppDelegate theDelegate] showRoom:room.state.roomId withMatrixSession:self.mainSession];
+                 [[AppDelegate theDelegate] showRoom:room.state.roomId andEventId:nil withMatrixSession:self.mainSession];
              } failure:^(NSError *error)
              {
                  NSLog(@"[Vector RoomVC] Join roomAlias (%@) failed", roomAlias);


### PR DESCRIPTION
Universal links are declared at:
https://vector.im/apple-app-site-association

The app currently supports a subset of possible vector.im links:
- links to room (id or room alias). ex: #/room/#freenode_#matrix:matrix.org
- links to permalinks. ex: #/room/!cURbafjkfsMDVwdRDQ:matrix.org/$1460364457773248cLoWe:matrix.org

Links not yet supported:
- 3PID invite to a room
- the next link in the registration process
- etc.

