### PR TITLE
Connect the universal link management in AppDelegate to the preview or RoomVC 

### DIFF
--- a/Vector.xcodeproj/project.pbxproj
+++ b/Vector.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		32AAC3E61C3525DE007A3B5B /* RoomSearchViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 32AAC3E51C3525DE007A3B5B /* RoomSearchViewController.m */; };
 		32AAC3E91C353CEA007A3B5B /* RoomSearchDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 32AAC3E81C353CEA007A3B5B /* RoomSearchDataSource.m */; };
 		32C52BF61CBE4B0A00863B33 /* RoomEmailInvitation.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C52BF51CBE4B0A00863B33 /* RoomEmailInvitation.m */; };
+		32C52BF91CBFF50C00863B33 /* RoomPreviewData.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C52BF81CBFF50C00863B33 /* RoomPreviewData.m */; };
 		32D0A4BC1CA44509008F3451 /* plus_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 32D0A4B91CA44509008F3451 /* plus_icon.png */; };
 		32D0A4BD1CA44509008F3451 /* plus_icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 32D0A4BA1CA44509008F3451 /* plus_icon@2x.png */; };
 		32D0A4BE1CA44509008F3451 /* plus_icon@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 32D0A4BB1CA44509008F3451 /* plus_icon@3x.png */; };
@@ -281,6 +282,8 @@
 		32AAC3E81C353CEA007A3B5B /* RoomSearchDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RoomSearchDataSource.m; sourceTree = "<group>"; };
 		32C52BF41CBE4B0A00863B33 /* RoomEmailInvitation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RoomEmailInvitation.h; sourceTree = "<group>"; };
 		32C52BF51CBE4B0A00863B33 /* RoomEmailInvitation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RoomEmailInvitation.m; sourceTree = "<group>"; };
+		32C52BF71CBFF50C00863B33 /* RoomPreviewData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RoomPreviewData.h; sourceTree = "<group>"; };
+		32C52BF81CBFF50C00863B33 /* RoomPreviewData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RoomPreviewData.m; sourceTree = "<group>"; };
 		32D0A4B91CA44509008F3451 /* plus_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = plus_icon.png; sourceTree = "<group>"; };
 		32D0A4BA1CA44509008F3451 /* plus_icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "plus_icon@2x.png"; sourceTree = "<group>"; };
 		32D0A4BB1CA44509008F3451 /* plus_icon@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "plus_icon@3x.png"; sourceTree = "<group>"; };
@@ -821,10 +824,12 @@
 				F05894FF1B8B7E6600B73E85 /* RoomBubbleCellData.m */,
 				F08BE0A01B87064000C480FB /* RoomDataSource.h */,
 				F08BE0A11B87064000C480FB /* RoomDataSource.m */,
-				32AAC3E71C353CEA007A3B5B /* RoomSearchDataSource.h */,
-				32AAC3E81C353CEA007A3B5B /* RoomSearchDataSource.m */,
 				32C52BF41CBE4B0A00863B33 /* RoomEmailInvitation.h */,
 				32C52BF51CBE4B0A00863B33 /* RoomEmailInvitation.m */,
+				32C52BF71CBFF50C00863B33 /* RoomPreviewData.h */,
+				32C52BF81CBFF50C00863B33 /* RoomPreviewData.m */,
+				32AAC3E71C353CEA007A3B5B /* RoomSearchDataSource.h */,
+				32AAC3E81C353CEA007A3B5B /* RoomSearchDataSource.m */,
 			);
 			path = Room;
 			sourceTree = "<group>";
@@ -1455,6 +1460,7 @@
 				717928471C03852C00407D96 /* TableViewCellWithLabelAndLargeTextView.m in Sources */,
 				F0D2D9871C197DCB007B8C96 /* RoomIncomingTextMsgBubbleCell.m in Sources */,
 				F0BE3DF01C6CE17200AC3111 /* RoomMemberDetailsViewController.m in Sources */,
+				32C52BF91CBFF50C00863B33 /* RoomPreviewData.m in Sources */,
 				F0C34B6F1C15CA2E00C36F09 /* RoomOutgoingAttachmentWithPaginationTitleBubbleCell.m in Sources */,
 				7165A25B1C05CD42003635D7 /* SegmentedViewController.m in Sources */,
 				F09E24ED1C6DE24900D39503 /* RoomMemberTitleView.m in Sources */,

--- a/Vector/AppDelegate.m
+++ b/Vector/AppDelegate.m
@@ -843,16 +843,17 @@
                 if (queryParams)
                 {
                     roomPreviewData = [[RoomPreviewData alloc] initWithRoomId:roomIdOrAlias emailInvitationParams:queryParams andSession:account.mxSession];
+                    [self showRoomPreview:roomPreviewData];
                 }
                 else
                 {
                     roomPreviewData = [[RoomPreviewData alloc] initWithRoomId:roomIdOrAlias andSession:account.mxSession];
 
-                    // TODO: Try to get more information about the room
-                    // We could attempt to do a room initialSync on it
+                    // Try to get more information about the room before opening its preview
+                    [roomPreviewData fetchPreviewData:^(BOOL successed) {
+                        [self showRoomPreview:roomPreviewData];
+                    }];
                 }
-
-                [self showRoomPreview:roomPreviewData];
             }
         }
         else

--- a/Vector/AppDelegate.m
+++ b/Vector/AppDelegate.m
@@ -834,8 +834,25 @@
             }
             else
             {
-                // TODO: Is it an invite?
-                NSLog(@"[AppDelegate] Universal link: The room (%@) is not known by any account", roomIdOrAlias);
+                NSLog(@"[AppDelegate] Universal link: The room (%@) is not known by any account (email invitation: %@). Display its preview to try to join it", roomIdOrAlias, queryParams ? @"YES" : @"NO");
+
+                // FIXME: In case of multi-account, ask the user which one to use
+                MXKAccount* account = accountManager.activeAccounts.firstObject;
+
+                RoomPreviewData *roomPreviewData;
+                if (queryParams)
+                {
+                    roomPreviewData = [[RoomPreviewData alloc] initWithRoomId:roomIdOrAlias emailInvitationParams:queryParams andSession:account.mxSession];
+                }
+                else
+                {
+                    roomPreviewData = [[RoomPreviewData alloc] initWithRoomId:roomIdOrAlias andSession:account.mxSession];
+
+                    // TODO: Try to get more information about the room
+                    // We could attempt to do a room initialSync on it
+                }
+
+                [self showRoomPreview:roomPreviewData];
             }
         }
         else
@@ -1386,6 +1403,13 @@
         // Select room to display its details (dispatch this action in order to let TabBarController end its refresh)
         [_homeViewController selectRoomWithId:roomId andEventId:eventId inMatrixSession:mxSession];
         
+    }];
+}
+
+- (void)showRoomPreview:(RoomPreviewData*)roomPreviewData
+{
+    [self restoreInitialDisplay:^{
+        [_homeViewController showRoomPreview:roomPreviewData];
     }];
 }
 

--- a/Vector/Assets/en.lproj/Vector.strings
+++ b/Vector/Assets/en.lproj/Vector.strings
@@ -157,6 +157,8 @@
 "room_preview_invitation_format" = "You have been invited to join this room by %@";
 "room_preview_subtitle" = "This is a preview of this room. Files and other attachments have been disabled.";
 "room_preview_unlinked_email_warning" = "This invitation was sent to %@, which is not associated with this account.\nYou may wish to login with a different account, or add this email to your this account.";
+"room_preview_try_join_an_unknown_room" = "You are trying to access %@. Would you like to join in order to participate in the discussion?";
+"room_preview_try_join_an_unknown_room_default" = "a room";
 
 // Settings
 "account_logout_all" = "Logout all accounts";

--- a/Vector/Model/Room/RoomEmailInvitation.h
+++ b/Vector/Model/Room/RoomEmailInvitation.h
@@ -25,7 +25,7 @@
 /**
  The room in the invitation.
  */
-@property (nonatomic, readonly) NSString *roomId;
+@property (nonatomic, readonly) NSString *roomId; // TODO
 
 /**
  The invitation parameters.
@@ -42,10 +42,9 @@
 
 /**
  Contructor and parser of the query params of the email link.
- 
- @param roomId the targeted room.
+
  @param params the query parameters extracted from the link.
  */
-- (instancetype)initWithRoomId:(NSString*)roomId andParams:(NSDictionary*)params;
+- (instancetype)initWithParams:(NSDictionary*)params;
 
 @end

--- a/Vector/Model/Room/RoomEmailInvitation.h
+++ b/Vector/Model/Room/RoomEmailInvitation.h
@@ -23,11 +23,6 @@
 @interface RoomEmailInvitation : NSObject
 
 /**
- The room in the invitation.
- */
-@property (nonatomic, readonly) NSString *roomId; // TODO
-
-/**
  The invitation parameters.
  Can be nil.
  */

--- a/Vector/Model/Room/RoomPreviewData.h
+++ b/Vector/Model/Room/RoomPreviewData.h
@@ -44,7 +44,8 @@
 @property (nonatomic) MXSession *mxSession;
 
 /**
- TODO
+ Preview information.
+ They come from the `emailInvitationParams` or [self fetchPreviewData].
  */
 @property (nonatomic, readonly) NSString *roomName;
 @property (nonatomic, readonly) NSString *roomAvatarUrl;
@@ -59,5 +60,16 @@
  */
 - (instancetype)initWithRoomId:(NSString*)roomId andSession:(MXSession*)mxSession;
 - (instancetype)initWithRoomId:(NSString*)roomId emailInvitationParams:(NSDictionary*)emailInvitationParams andSession:(MXSession*)mxSession;
+
+/**
+ Attempt to get more information from the homeserver about the room.
+
+ NOTE: This method is temporary while we do not support the full room preview
+       with preview of messages.
+ 
+ @param completion the block called when the request is complete. `successed` means
+        the homeserver provided some information.
+ */
+- (void)fetchPreviewData:(void (^)(BOOL successed))completion;
 
 @end

--- a/Vector/Model/Room/RoomPreviewData.h
+++ b/Vector/Model/Room/RoomPreviewData.h
@@ -1,0 +1,63 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "RoomEmailInvitation.h"
+#import "MXSession.h"
+
+/**
+ The `RoomEmailInvitation` gathers information for displaying the preview of a
+ room that is unknown for the user.
+
+ Such room can come from an email invitation link or a link to a room.
+ */
+
+@interface RoomPreviewData : NSObject
+
+/**
+ The id of the room to preview.
+ */
+@property (nonatomic, readonly) NSString *roomId;
+
+/**
+ In case of email invitation, the information extracted from the email invitation link.
+ */
+@property (nonatomic, readonly) RoomEmailInvitation *emailInvitation;
+
+/**
+ The matrix session to show the data.
+ */
+@property (nonatomic) MXSession *mxSession;
+
+/**
+ TODO
+ */
+@property (nonatomic, readonly) NSString *roomName;
+@property (nonatomic, readonly) NSString *roomAvatarUrl;
+@property (nonatomic, readonly) NSString *roomTopic;
+
+/**
+ Contructors.
+ 
+ @param roomId the id of the room.
+ @param emailInvitationParams, in case of an email invitation link, the query parameters extracted from the link.
+ @param mxSession the session to open the room preview with.
+ */
+- (instancetype)initWithRoomId:(NSString*)roomId andSession:(MXSession*)mxSession;
+- (instancetype)initWithRoomId:(NSString*)roomId emailInvitationParams:(NSDictionary*)emailInvitationParams andSession:(MXSession*)mxSession;
+
+@end

--- a/Vector/Model/Room/RoomPreviewData.m
+++ b/Vector/Model/Room/RoomPreviewData.m
@@ -35,6 +35,10 @@
     if (self)
     {
         _emailInvitation = [[RoomEmailInvitation alloc] initWithParams:emailInvitationParams];
+
+        // Report decoded data
+        _roomName = _emailInvitation.roomName;
+        _roomAvatarUrl = _emailInvitation.roomAvatarUrl;
     }
     return self;
 }

--- a/Vector/Model/Room/RoomPreviewData.m
+++ b/Vector/Model/Room/RoomPreviewData.m
@@ -14,26 +14,29 @@
  limitations under the License.
  */
 
-#import "RoomEmailInvitation.h"
+#import "RoomPreviewData.h"
 
-@implementation RoomEmailInvitation
+@implementation RoomPreviewData
 
-- (instancetype)initWithParams:(NSDictionary *)params
+- (instancetype)initWithRoomId:(NSString *)roomId andSession:(MXSession *)mxSession
 {
     self = [super init];
     if (self)
     {
-        if (params)
-        {
-            _email = params[@"email"];
-            _signUrl = params[@"signurl"];
-            _roomName = params[@"room_name"];
-            _roomAvatarUrl = params[@"room_avatar_url"];
-            _inviterName = params[@"inviter_name"];
-            _guestAccessToken = params[@"guest_access_token"];
-            _guestUserId = params[@"guest_user_id"];
-        }
+        _roomId = roomId;
+        _mxSession = mxSession;
     }
     return self;
 }
+
+- (instancetype)initWithRoomId:(NSString *)roomId emailInvitationParams:(NSDictionary *)emailInvitationParams andSession:(MXSession *)mxSession
+{
+    self = [self initWithRoomId:roomId andSession:mxSession];
+    if (self)
+    {
+        _emailInvitation = [[RoomEmailInvitation alloc] initWithParams:emailInvitationParams];
+    }
+    return self;
+}
+
 @end

--- a/Vector/Model/Room/RoomPreviewData.m
+++ b/Vector/Model/Room/RoomPreviewData.m
@@ -43,4 +43,33 @@
     return self;
 }
 
+- (void)fetchPreviewData:(void (^)(BOOL))completion
+{
+    // Make an /initialSync request to get preview data
+    [_mxSession.matrixRestClient initialSyncOfRoom:_roomId withLimit:0 success:^(MXRoomInitialSync *roomInitialSync) {
+
+        MXRoomState *roomState = [[MXRoomState alloc] initWithRoomId:_roomId andMatrixSession:_mxSession andDirection:YES];
+
+        // Make roomState digest state events of the room
+        for (MXEvent *stateEvent in roomInitialSync.state)
+        {
+            // Skip members events as they are not not interesting here and can be numerous
+            if (stateEvent.eventType != MXEventTypeRoomMember)
+            {
+                [roomState handleStateEvent:stateEvent];
+            }
+        }
+
+        // Report retrieved data
+        _roomName = roomState.displayname;
+        _roomAvatarUrl = roomState.avatar;
+        _roomTopic = roomState.topic;
+
+        completion(YES);
+
+    } failure:^(NSError *error) {
+        completion(NO);
+    }];
+}
+
 @end

--- a/Vector/ViewController/HomeViewController.h
+++ b/Vector/ViewController/HomeViewController.h
@@ -17,8 +17,7 @@
 #import <MatrixKit/MatrixKit.h>
 
 #import "SegmentedViewController.h"
-
-@class RoomViewController;
+#import "RoomViewController.h"
 
 /**
  The `HomeViewController` screen is the main app screen.
@@ -33,6 +32,7 @@
 @property (nonatomic, readonly) NSString  *selectedRoomId;
 @property (nonatomic, readonly) NSString  *selectedEventId;
 @property (nonatomic, readonly) MXSession *selectedRoomSession;
+@property (nonatomic, readonly) RoomPreviewData *selectedRoomPreviewData;
 
 
 /**
@@ -55,6 +55,15 @@
  @param mxSession the matrix session in which the room should be available.
  */
 - (void)selectRoomWithId:(NSString*)roomId andEventId:(NSString*)eventId inMatrixSession:(MXSession*)mxSession;
+
+/**
+ Open the RoomViewController to display the preview of a room that is unknown for the user.
+
+ This room can come from an email invitation link or a simple link to a room.
+
+ @param roomPreviewData the data for the room preview.
+ */
+- (void)showRoomPreview:(RoomPreviewData*)roomPreviewData;
 
 /**
  Close the current selected room (if any)

--- a/Vector/ViewController/RoomViewController.h
+++ b/Vector/ViewController/RoomViewController.h
@@ -18,7 +18,7 @@
 
 #import "RoomTitleView.h"
 
-#import "RoomEmailInvitation.h"
+#import "RoomPreviewData.h"
 
 #import "UIViewController+VectorSearch.h"
 
@@ -39,11 +39,13 @@
 - (void)showExpandedHeader:(BOOL)isVisible;
 
 /**
- Display an invitation preview.
- 
- @param emailInvitation the invitation received by email.
+ Display the preview of a room that is unknown for the user.
+
+ This room can come from an email invitation link or a simple link to a room.
+
+ @param roomPreviewData the data for the room preview.
  */
-- (void)displayEmailInvitation:(RoomEmailInvitation*)emailInvitation;
+- (void)displayRoomPreview:(RoomPreviewData*)previewData;
 
 @end
 

--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -717,7 +717,7 @@
             {
                 previewHeader.mxRoom = self.roomDataSource.room;
             }
-            else
+            else if (roomEmailInvitation)
             {
                 previewHeader.emailInvitation = roomEmailInvitation;
 
@@ -1430,7 +1430,16 @@
     {
         if (roomEmailInvitation)
         {
-            //FIXME Accept the invitation
+            // Attempt to join the room
+            [self joinRoomWithRoomId:roomEmailInvitation.roomId andSignUrl:roomEmailInvitation.signUrl completion:^(BOOL succeed) {
+
+                if (succeed)
+                {
+                    roomEmailInvitation = nil;
+                    [self refreshRoomTitle];
+                }
+
+            }];
         }
         else
         {
@@ -1448,7 +1457,8 @@
     {
         if (roomEmailInvitation)
         {
-            //FIXME Decline this invitation
+            // Decline this invitation = leave this page
+            [[AppDelegate theDelegate] restoreInitialDisplay:^{}];
         }
         else
         {

--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -1430,10 +1430,10 @@
     }
     else if (view == previewHeader.leftButton)
     {
-        if (roomPreviewData.emailInvitation)
+        if (roomPreviewData)
         {
             // Attempt to join the room
-            // TODO: link without invitation params
+            // Note in case of simple link to a room the signUrl param is nil
             [self joinRoomWithRoomId:roomPreviewData.roomId andSignUrl:roomPreviewData.emailInvitation.signUrl completion:^(BOOL succeed) {
 
                 if (succeed)

--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -1439,7 +1439,19 @@
                 if (succeed)
                 {
                     roomPreviewData = nil;
+
+                    // Enable back the text input
+                    [self setRoomInputToolbarViewClass:RoomInputToolbarView.class];
+
+                    [UIView setAnimationsEnabled:NO];
+                    [self roomInputToolbarView:self.inputToolbarView heightDidChanged:((RoomInputToolbarView*)self.inputToolbarView).mainToolbarMinHeightConstraint.constant completion:nil];
+                    [UIView setAnimationsEnabled:YES];
+
+                    // And the extra area
+                    [self setRoomActivitiesViewClass:RoomActivitiesView.class];
+
                     [self refreshRoomTitle];
+                    [self refreshRoomInputToolbar];
                 }
 
             }];

--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -719,7 +719,7 @@
             }
             else if (roomPreviewData)
             {
-                previewHeader.emailInvitation = roomPreviewData.emailInvitation; //TODO
+                previewHeader.roomPreviewData = roomPreviewData;
 
                 if (roomPreviewData.emailInvitation.email)
                 {
@@ -760,12 +760,12 @@
             
             shadowImage = [[UIImage alloc] init];
 
-            // Set the avatar provided by the email invitation
-            if (roomPreviewData.emailInvitation.roomAvatarUrl)
+            // Set the avatar provided in preview data
+            if (roomPreviewData.roomAvatarUrl)
             {
                 RoomAvatarTitleView *roomAvatarTitleView = (RoomAvatarTitleView*)self.titleView;
                 MXKImageView *roomAvatarView = roomAvatarTitleView.roomAvatar;
-                NSString *roomAvatarUrl = [self.mainSession.matrixRestClient urlOfContentThumbnail:roomPreviewData.emailInvitation.roomAvatarUrl toFitViewSize:roomAvatarView.frame.size withMethod:MXThumbnailingMethodCrop];
+                NSString *roomAvatarUrl = [self.mainSession.matrixRestClient urlOfContentThumbnail:roomPreviewData.roomAvatarUrl toFitViewSize:roomAvatarView.frame.size withMethod:MXThumbnailingMethodCrop];
 
                 roomAvatarTitleView.roomAvatarURL = roomAvatarUrl;
             }

--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -243,6 +243,12 @@
     }
     else
     {
+        if (roomEmailInvitation)
+        {
+            // Set room title view
+            [self refreshRoomTitle];
+        }
+
         self.navigationItem.rightBarButtonItem.enabled = NO;
     }
 }
@@ -714,6 +720,16 @@
             else
             {
                 previewHeader.emailInvitation = roomEmailInvitation;
+
+                if (roomEmailInvitation.email)
+                {
+                    // Warn the user that the email is not bound to his matrix account
+                    previewHeader.subInvitationLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_preview_unlinked_email_warning", @"Vector", nil), roomEmailInvitation.email];
+
+                    // room_preview_unlinked_email_warning is long long long and overlaps
+                    // bottomBorderView. So, hide this last one.
+                    previewHeader.bottomBorderView.hidden = YES;
+                }
             }
         }
         
@@ -743,6 +759,16 @@
             roomAvatarView.alpha = 0.0;
             
             shadowImage = [[UIImage alloc] init];
+
+            // Set the avatar provided by the email invitation
+            if (roomEmailInvitation && roomEmailInvitation.roomAvatarUrl)
+            {
+                RoomAvatarTitleView *roomAvatarTitleView = (RoomAvatarTitleView*)self.titleView;
+                MXKImageView *roomAvatarView = roomAvatarTitleView.roomAvatar;
+                NSString *roomAvatarUrl = [self.mainSession.matrixRestClient urlOfContentThumbnail:roomEmailInvitation.roomAvatarUrl toFitViewSize:roomAvatarView.frame.size withMethod:MXThumbnailingMethodCrop];
+
+                roomAvatarTitleView.roomAvatarURL = roomAvatarUrl;
+            }
         }
         else
         {
@@ -778,27 +804,8 @@
     if (emailInvitation)
     {
         roomEmailInvitation = emailInvitation;
-        previewHeader.emailInvitation = emailInvitation;
         
         [self refreshRoomTitle];
-        
-        if (emailInvitation.roomAvatarUrl)
-        {
-            if ([self.titleView isKindOfClass:RoomAvatarTitleView.class])
-            {
-                RoomAvatarTitleView *roomAvatarTitleView = (RoomAvatarTitleView*)self.titleView;
-                MXKImageView *roomAvatarView = roomAvatarTitleView.roomAvatar;
-                NSString *roomAvatarUrl = [self.roomDataSource.mxSession.matrixRestClient urlOfContentThumbnail:emailInvitation.roomAvatarUrl toFitViewSize:roomAvatarView.frame.size withMethod:MXThumbnailingMethodCrop];
-                
-                roomAvatarTitleView.roomAvatarURL = roomAvatarUrl;
-            }            
-        }
-        
-        if (emailInvitation.email)
-        {
-            // FIXME: Check whether the email is linked or not to the account
-            // If it is not linked, use 'previewHeader.subInvitationLabel' to warm the user with predefined string 'room_preview_unlinked_email_warning'.
-        }
     }
 }
 

--- a/Vector/Views/RoomTitle/PreviewRoomTitleView.h
+++ b/Vector/Views/RoomTitle/PreviewRoomTitleView.h
@@ -16,7 +16,7 @@
 
 #import "RoomTitleView.h"
 
-#import "RoomEmailInvitation.h"
+#import "RoomPreviewData.h"
 
 @interface PreviewRoomTitleView : RoomTitleView
 
@@ -32,6 +32,6 @@
 @property (weak, nonatomic) IBOutlet UILabel *subInvitationLabel;
 @property (weak, nonatomic) IBOutlet UIView *bottomBorderView;
 
-@property (strong, nonatomic) RoomEmailInvitation *emailInvitation;
+@property (strong, nonatomic) RoomPreviewData *roomPreviewData;
 
 @end

--- a/Vector/Views/RoomTitle/PreviewRoomTitleView.m
+++ b/Vector/Views/RoomTitle/PreviewRoomTitleView.m
@@ -135,11 +135,25 @@
         
         self.invitationLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_preview_invitation_format", @"Vector", nil), inviter];
     }
-    else if (self.emailInvitation)
+    else if (self.roomPreviewData)
     {
-        self.displayNameTextField.text = self.emailInvitation.roomName;
+        self.displayNameTextField.text = self.roomPreviewData.roomName;
         self.roomMembers.text = nil;
-        self.invitationLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_preview_invitation_format", @"Vector", nil), self.emailInvitation.inviterName];
+
+        if (self.roomPreviewData.emailInvitation.email)
+        {
+            self.invitationLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_preview_invitation_format", @"Vector", nil), self.roomPreviewData.emailInvitation.inviterName];
+        }
+        else
+        {
+            // This is a room opened from a room link
+            NSString *roomName = self.roomPreviewData.roomName;
+            if (!roomName)
+            {
+                roomName = NSLocalizedStringFromTable(@"room_preview_try_join_an_unknown_room_default", @"Vector", nil);
+            }
+            self.invitationLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_preview_try_join_an_unknown_room", @"Vector", nil), roomName];
+        }
     }
     else
     {
@@ -148,11 +162,9 @@
     }
 }
 
-- (void)setEmailInvitation:(RoomEmailInvitation *)emailInvitation
+- (void)setRoomPreviewData:(RoomPreviewData *)roomPreviewData
 {
-    _emailInvitation = emailInvitation;
-    
-    [self refreshDisplay];
+    _roomPreviewData = roomPreviewData;
 }
 
 @end

--- a/Vector/Views/RoomTitle/RoomAvatarTitleView.m
+++ b/Vector/Views/RoomTitle/RoomAvatarTitleView.m
@@ -80,6 +80,10 @@
     else if (self.roomAvatarURL)
     {
         [self.roomAvatar setImageURL:self.roomAvatarURL withType:nil andImageOrientation:UIImageOrientationUp previewImage:[UIImage imageNamed:@"placeholder"]];        
+
+        // Round image view for thumbnail
+        self.roomAvatar.layer.cornerRadius = self.roomAvatar.frame.size.width / 2;
+        self.roomAvatar.clipsToBounds = YES;
     }
     else
     {


### PR DESCRIPTION
[roomVC displayEmailInvitation] has been renamed to [roomVC displayRoomPreview] .
It display room preview from email invitation link or from a simple link to a room.

In the case of simple link, we try to get more info (room name, avatar, url) from the homeserver. There is **no preview on messages** yet.