### PR TITLE
AppDelegate: Added fixURLWithSeveralHashKeys method to fix iOS NSURLs with several #

### DIFF
--- a/Vector/AppDelegate.h
+++ b/Vector/AppDelegate.h
@@ -103,5 +103,17 @@
  */
 - (BOOL)handleUniversalLinkFragment:(NSString*)fragment;
 
+/**
+ Fix a http://vector.im path url.
+ 
+ This method fixes the issue with iOS which handles URL badly when there are several hash
+ keys ('%23') in the link.
+ Vector.im links have often several hash keys...
+
+ @param url a NSURL with possibly several hash keys and thus badly parsed.
+ @return a NSURL correctly parsed.
+ */
++ (NSURL*)fixURLWithSeveralHashKeys:(NSURL*)url;
+
 @end
 

--- a/Vector/AppDelegate.m
+++ b/Vector/AppDelegate.m
@@ -747,6 +747,9 @@
     NSURL *webURL = userActivity.webpageURL;
     NSLog(@"[AppDelegate] handleUniversalLink: %@", webURL.absoluteString);
 
+    // iOS Patch: fix vector.im urls before using it
+    webURL = [AppDelegate fixURLWithSeveralHashKeys:webURL];
+
     return [self handleUniversalLinkFragment:webURL.fragment];
 }
 
@@ -765,6 +768,14 @@
     NSArray<NSString*> *pathParams;
     NSMutableDictionary *queryParams;
     [self parseUniversalLinkFragment:fragment outPathParams:&pathParams outQueryParams:&queryParams];
+
+    // Sanity check
+    pathParams = nil;
+    if (!pathParams.count)
+    {
+        NSLog(@"[AppDelegate] Universal link: Error: No path parameters");
+        return NO;
+    }
 
     // Check the action to do
     if ([pathParams[0] isEqualToString:@"room"] && pathParams.count >= 2)
@@ -992,6 +1003,26 @@
 
     *outPathParams = pathParams;
     *outQueryParams = queryParams;
+}
+
++ (NSURL *)fixURLWithSeveralHashKeys:(NSURL *)url
+{
+    NSURL *fixedURL;
+
+    // Replacing the first '%23' occurence into a '#' makes NSURL works correctly
+    NSString *urlString = url.absoluteString;
+    NSRange range = [urlString rangeOfString:@"%23"];
+    if (NSNotFound != range.location)
+    {
+        urlString = [urlString stringByReplacingCharactersInRange:range withString:@"#"];
+        fixedURL = [NSURL URLWithString:urlString];
+    }
+    else
+    {
+        fixedURL = url;
+    }
+
+    return fixedURL;
 }
 
 #pragma mark - Matrix sessions handling

--- a/Vector/AppDelegate.m
+++ b/Vector/AppDelegate.m
@@ -770,7 +770,6 @@
     [self parseUniversalLinkFragment:fragment outPathParams:&pathParams outQueryParams:&queryParams];
 
     // Sanity check
-    pathParams = nil;
     if (!pathParams.count)
     {
         NSLog(@"[AppDelegate] Universal link: Error: No path parameters");

--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -1275,18 +1275,10 @@
         // Try to catch universal link supported by the app
         NSURL *url = userInfo[kMXKRoomBubbleCellUrl];
 
-        // Patch: iOS handles URL badly when there are several hash keys ('%23') in the link
-        // And vector.im links have often several hash keys...
+        // iOS Patch: fix vector.im urls before using it
         if ([url.host isEqualToString:@"vector.im"])
         {
-            // Replacing the first '%23' occurence into a '#' makes NSURL works correctly
-            NSString *urlString = url.absoluteString;
-            NSRange range = [urlString rangeOfString:@"%23"];
-            if (NSNotFound != range.location)
-            {
-                urlString = [urlString stringByReplacingCharactersInRange:range withString:@"#"];
-                url = [NSURL URLWithString:urlString];
-            }
+            url = [AppDelegate fixURLWithSeveralHashKeys:url];
 
             // If the link can be open it by the app, let it do
             if ([[AppDelegate theDelegate] isUniversalLink:url])


### PR DESCRIPTION
Use this method on in-app and from outside links.
