### PR TITLE
RoomViewController: Fixed crash on 6+: "Starting the app in portrait,…

### DIFF
--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -366,7 +366,7 @@
         [self showExpandedHeader:NO];
         
         // Hide preview header (if any) during device rotation
-        BOOL isPreview = !self.previewScrollView.isHidden;
+        BOOL isPreview = self.previewScrollView && !self.previewScrollView.isHidden;
         if (isPreview)
         {
             [self showPreviewHeader:NO];


### PR DESCRIPTION
… then rotate the device in landscaped" made the app crash.

The reason is that in these conditions, there is no selected room. So, self.previewScrollView is nil