### PR TITLE
Update room members list

### DIFF
--- a/Vector.xcodeproj/project.pbxproj
+++ b/Vector.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		325F6A481C21D4C100C12F51 /* chevron@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 325F6A451C21D4C100C12F51 /* chevron@2x.png */; };
 		325F6A491C21D4C100C12F51 /* chevron@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 325F6A461C21D4C100C12F51 /* chevron@3x.png */; };
 		327F8DB51C64DB9D00581CA3 /* VectorDesignValues.m in Sources */ = {isa = PBXBuildFile; fileRef = 327F8DB41C64DB9C00581CA3 /* VectorDesignValues.m */; };
+		329D08101CD26177007CECC6 /* Tools.m in Sources */ = {isa = PBXBuildFile; fileRef = 329D080F1CD26177007CECC6 /* Tools.m */; };
 		32A887211C89B9580037DC17 /* SimpleRoomTitleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 32A8871F1C89B9580037DC17 /* SimpleRoomTitleView.m */; };
 		32A887221C89B9580037DC17 /* SimpleRoomTitleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 32A887201C89B9580037DC17 /* SimpleRoomTitleView.xib */; };
 		32AAC3E61C3525DE007A3B5B /* RoomSearchViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 32AAC3E51C3525DE007A3B5B /* RoomSearchViewController.m */; };
@@ -273,6 +274,8 @@
 		325F6A451C21D4C100C12F51 /* chevron@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "chevron@2x.png"; sourceTree = "<group>"; };
 		325F6A461C21D4C100C12F51 /* chevron@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "chevron@3x.png"; sourceTree = "<group>"; };
 		327F8DB41C64DB9C00581CA3 /* VectorDesignValues.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VectorDesignValues.m; sourceTree = "<group>"; };
+		329D080E1CD26177007CECC6 /* Tools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Tools.h; sourceTree = "<group>"; };
+		329D080F1CD26177007CECC6 /* Tools.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Tools.m; sourceTree = "<group>"; };
 		32A8871E1C89B9580037DC17 /* SimpleRoomTitleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SimpleRoomTitleView.h; path = RoomTitle/SimpleRoomTitleView.h; sourceTree = "<group>"; };
 		32A8871F1C89B9580037DC17 /* SimpleRoomTitleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SimpleRoomTitleView.m; path = RoomTitle/SimpleRoomTitleView.m; sourceTree = "<group>"; };
 		32A887201C89B9580037DC17 /* SimpleRoomTitleView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = SimpleRoomTitleView.xib; path = RoomTitle/SimpleRoomTitleView.xib; sourceTree = "<group>"; };
@@ -813,6 +816,8 @@
 				327F8DB41C64DB9C00581CA3 /* VectorDesignValues.m */,
 				F08BE09C1B87025B00C480FB /* EventFormatter.h */,
 				F08BE09D1B87025B00C480FB /* EventFormatter.m */,
+				329D080E1CD26177007CECC6 /* Tools.h */,
+				329D080F1CD26177007CECC6 /* Tools.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1484,6 +1489,7 @@
 				F05895001B8B7E6600B73E85 /* RoomBubbleCellData.m in Sources */,
 				71F7F5181C22CC7500E7ED8F /* MXRoom+Vector.m in Sources */,
 				F0D2D9831C197DCB007B8C96 /* RoomIncomingAttachmentBubbleCell.m in Sources */,
+				329D08101CD26177007CECC6 /* Tools.m in Sources */,
 				F09EE0041C5134BE0078712F /* RoomIncomingTextMsgWithPaginationTitleWithoutSenderNameBubbleCell.m in Sources */,
 				F0C34B611C15C28300C36F09 /* RoomOutgoingAttachmentBubbleCell.m in Sources */,
 				71C5F2951C074ACC004C094B /* RoomSettingsViewController.m in Sources */,

--- a/Vector/Assets/en.lproj/Vector.strings
+++ b/Vector/Assets/en.lproj/Vector.strings
@@ -111,11 +111,12 @@
 
 "room_participants_invited_section" = "INVITED";
 
-"room_participants_active" = "Online";
-"room_participants_active_less_1_hour" = "Offline";
-"room_participants_active_less_x_hours" = "Offline %luh ago";
-"room_participants_active_less_x_days" = "Offline %lu days ago";
+"room_participants_online" = "Online";
 "room_participants_offline" = "Offline";
+"room_participants_unkown" = "Unkwown";
+"room_participants_idle" = "Idle";
+"room_participants_now" = "now";
+"room_participants_ago" = "ago";
 
 "room_participants_action_invite" = "Invite";
 "room_participants_action_leave" = "Leave this room";

--- a/Vector/Assets/en.lproj/Vector.strings
+++ b/Vector/Assets/en.lproj/Vector.strings
@@ -105,7 +105,6 @@
 "room_participants_leave_prompt_msg" = "Are you sure you want to leave this chat?";
 "room_participants_remove_prompt_title" = "Remove?";
 "room_participants_remove_prompt_msg" = "Are you sure you want to remove %@ from this chat?";
-"room_participants_admin_name" = "%@ (admin)";
 "room_participants_invite_another_user" = "Invite/search by name, email, id";
 "room_participants_invite_malformed_id_title" = "Invite Error";
 "room_participants_invite_malformed_id" = "Malformed ID. Should be an email address or a Matrix ID like '@localpart:domain'";

--- a/Vector/Utils/Tools.h
+++ b/Vector/Utils/Tools.h
@@ -1,0 +1,31 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MatrixKit/MatrixKit.h"
+
+@interface Tools : NSObject
+
+/**
+ Compute the text to display user's presence
+ 
+ @param user the user. Can be nil.
+ @return the string to display.
+ */
++ (NSString*)presenceText:(MXUser*)user;
+
+@end

--- a/Vector/Utils/Tools.m
+++ b/Vector/Utils/Tools.m
@@ -48,9 +48,8 @@
             presenceText = [presenceText stringByAppendingString:[NSString stringWithFormat:@" %@",
                                                                   NSLocalizedStringFromTable(@"room_participants_now", @"Vector", nil)]];
         }
-        else if (-1 != user.lastActiveAgo)
+        else if (0 < user.lastActiveAgo)
         {
-
             presenceText = [presenceText stringByAppendingString:[NSString stringWithFormat:@" %@ %@",
                                                                   [MXKTools formatSecondsIntervalFloored:(user.lastActiveAgo / 1000)],
                                                                   NSLocalizedStringFromTable(@"room_participants_ago", @"Vector", nil)]];

--- a/Vector/Utils/Tools.m
+++ b/Vector/Utils/Tools.m
@@ -43,7 +43,7 @@
                 break;
         }
 
-        if (user.isCurrentlyActive)
+        if (user.currentlyActive)
         {
             presenceText = [presenceText stringByAppendingString:[NSString stringWithFormat:@" %@",
                                                                   NSLocalizedStringFromTable(@"room_participants_now", @"Vector", nil)]];

--- a/Vector/Utils/Tools.m
+++ b/Vector/Utils/Tools.m
@@ -1,0 +1,63 @@
+/*
+ Copyright 2016 OpenMarket Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "Tools.h"
+
+@implementation Tools
+
++ (NSString *)presenceText:(MXUser *)user
+{
+    NSString* presenceText = NSLocalizedStringFromTable(@"room_participants_unkown", @"Vector", nil);
+
+    if (user)
+    {
+        switch (user.presence)
+        {
+            case MXPresenceOnline:
+                presenceText = NSLocalizedStringFromTable(@"room_participants_online", @"Vector", nil);
+                break;
+
+            case MXPresenceUnavailable:
+                presenceText = NSLocalizedStringFromTable(@"room_participants_idle", @"Vector", nil);
+                break;
+
+            case MXPresenceUnknown: // Do like matrix-js-sdk
+            case MXPresenceOffline:
+                presenceText = NSLocalizedStringFromTable(@"room_participants_offline", @"Vector", nil);
+                break;
+
+            default:
+                break;
+        }
+
+        if (user.isCurrentlyActive)
+        {
+            presenceText = [presenceText stringByAppendingString:[NSString stringWithFormat:@" %@",
+                                                                  NSLocalizedStringFromTable(@"room_participants_now", @"Vector", nil)]];
+        }
+        else if (-1 != user.lastActiveAgo)
+        {
+
+            presenceText = [presenceText stringByAppendingString:[NSString stringWithFormat:@" %@ %@",
+                                                                  [MXKTools formatSecondsIntervalFloored:(user.lastActiveAgo / 1000)],
+                                                                  NSLocalizedStringFromTable(@"room_participants_ago", @"Vector", nil)]];
+        }
+    }
+
+    return presenceText;
+}
+
+@end

--- a/Vector/ViewController/RoomMemberDetailsViewController.m
+++ b/Vector/ViewController/RoomMemberDetailsViewController.m
@@ -25,6 +25,7 @@
 #import "RageShakeManager.h"
 
 #import "AvatarGenerator.h"
+#import "Tools.h"
 
 #import "TableViewCellWithButton.h"
 
@@ -219,41 +220,12 @@
             memberTitleView.memberBadge.hidden = YES;
         }
         
-        NSString* presenceText = nil;
+        NSString* presenceText;
         
         if (self.mxRoomMember.userId)
         {
             MXUser *user = [self.mxRoom.mxSession userWithUserId:self.mxRoomMember.userId];
-            if (user)
-            {
-                if (user.presence == MXPresenceOnline)
-                {
-                    presenceText  = NSLocalizedStringFromTable(@"room_participants_active", @"Vector", nil);
-                }
-                else
-                {
-                    NSUInteger lastActiveMs = user.lastActiveAgo;
-                    
-                    if (-1 != lastActiveMs)
-                    {
-                        NSUInteger lastActivehour = lastActiveMs / 1000 / 60 / 60;
-                        NSUInteger lastActiveDays = lastActivehour / 24;
-                        
-                        if (lastActivehour < 1)
-                        {
-                            presenceText = NSLocalizedStringFromTable(@"room_participants_active_less_1_hour", @"Vector", nil);
-                        }
-                        else if (lastActivehour < 24)
-                        {
-                            presenceText = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_participants_active_less_x_hours", @"Vector", nil), lastActivehour];
-                        }
-                        else
-                        {
-                            presenceText = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_participants_active_less_x_days", @"Vector", nil), lastActiveDays];
-                        }
-                    }
-                }
-            }
+            presenceText = [Tools presenceText:user];
         }
         
         self.roomMemberStatusLabel.text = presenceText;

--- a/Vector/ViewController/RoomParticipantsViewController.m
+++ b/Vector/ViewController/RoomParticipantsViewController.m
@@ -453,7 +453,7 @@
 
         if (!userA && !userB)
         {
-            return NSOrderedSame;
+            return [contactA.sortingDisplayName compare:contactB.sortingDisplayName options:NSCaseInsensitiveSearch];
         }
         if (userA && !userB)
         {

--- a/Vector/ViewController/RoomParticipantsViewController.m
+++ b/Vector/ViewController/RoomParticipantsViewController.m
@@ -330,16 +330,7 @@
                 if (mxMember.membership == MXMembershipJoin || mxMember.membership == MXMembershipInvite)
                 {
                     // The user is in this room
-                    
-                    // Check whether user is admin
-                    MXRoomPowerLevels *powerLevels = [self.mxRoom.state powerLevels];
-                    BOOL isAdmin = ([powerLevels powerLevelOfUserWithUserID:userId] >= kVectorRoomAdminLevel);
-                    
                     NSString *displayName = NSLocalizedStringFromTable(@"you", @"Vector", nil);
-                    if (isAdmin)
-                    {
-                        displayName = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_participants_admin_name", @"Vector", nil), displayName];
-                    }
                     
                     userContact = [[Contact alloc] initMatrixContactWithDisplayName:displayName andMatrixID:userId];
                     userContact.mxMember = [self.mxRoom.state memberWithUserId:userId];
@@ -365,10 +356,6 @@
     // Add this member after checking his status
     if (mxMember.membership == MXMembershipJoin || mxMember.membership == MXMembershipInvite)
     {
-        // Check whether this member is admin
-        MXRoomPowerLevels *powerLevels = [self.mxRoom.state powerLevels];
-        BOOL isAdmin = ([powerLevels powerLevelOfUserWithUserID:mxMember.userId] >= kVectorRoomAdminLevel);
-        
         // Prepare the display name of this member
         NSString *displayName = mxMember.displayname;
         if (displayName.length == 0)
@@ -383,11 +370,6 @@
             {
                 displayName = mxMember.userId;
             }
-        }
-        
-        if (isAdmin)
-        {
-            displayName = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_participants_admin_name", @"Vector", nil), displayName];
         }
         
         // Create the contact related to this member

--- a/Vector/ViewController/RoomParticipantsViewController.m
+++ b/Vector/ViewController/RoomParticipantsViewController.m
@@ -30,10 +30,6 @@
 
 @interface RoomParticipantsViewController ()
 {
-    // Array used to sort participants and invited members
-    NSMutableArray *sortedParticipants;
-    NSMutableArray *sortedInvitedParticipants;
-    
     // Search session
     NSString *currentSearchText;
     UIView* searchBarSeparator;
@@ -127,9 +123,6 @@
     }
     
     _mxRoom = nil;
-    
-    sortedParticipants = nil;
-    sortedInvitedParticipants = nil;
     
     invitableContacts = nil;
     filteredActualParticipants = nil;
@@ -318,8 +311,8 @@
 
 - (void)refreshParticipantsFromRoomMembers
 {
-    sortedParticipants = [NSMutableArray array];
-    sortedInvitedParticipants = [NSMutableArray array];
+    actualParticipants = [NSMutableArray array];
+    invitedParticipants = [NSMutableArray array];
     userContact = nil;
     
     if (self.mxRoom)
@@ -403,11 +396,11 @@
 
         if (mxMember.membership == MXMembershipInvite)
         {
-            [sortedInvitedParticipants addObject:contact];
+            [invitedParticipants addObject:contact];
         }
         else
         {
-            [sortedParticipants addObject:contact];
+            [actualParticipants addObject:contact];
         }
     }
 }
@@ -421,7 +414,7 @@
         contact.isThirdPartyInvite = YES;
         contact.mxThirdPartyInvite = roomThirdPartyInvite;
 
-        [sortedInvitedParticipants addObject:contact];
+        [invitedParticipants addObject:contact];
     }
 }
 
@@ -430,35 +423,35 @@
 {
     NSUInteger index;
 
-    if (sortedParticipants.count)
+    if (actualParticipants.count)
     {
-        for (index = 0; index < sortedParticipants.count; index++)
+        for (index = 0; index < actualParticipants.count; index++)
         {
-            Contact *contact = sortedParticipants[index];
+            Contact *contact = actualParticipants[index];
             
             if (contact.mxMember && [contact.mxMember.userId isEqualToString:key])
             {
-                [sortedParticipants removeObjectAtIndex:index];
+                [actualParticipants removeObjectAtIndex:index];
                 return;
             }
         }
     }
     
-    if (sortedInvitedParticipants.count)
+    if (invitedParticipants.count)
     {
-        for (index = 0; index < sortedInvitedParticipants.count; index++)
+        for (index = 0; index < invitedParticipants.count; index++)
         {
-            Contact *contact = sortedInvitedParticipants[index];
+            Contact *contact = invitedParticipants[index];
             
             if (contact.mxMember && [contact.mxMember.userId isEqualToString:key])
             {
-                [sortedInvitedParticipants removeObjectAtIndex:index];
+                [invitedParticipants removeObjectAtIndex:index];
                 return;
             }
             
             if (contact.mxThirdPartyInvite && [contact.mxThirdPartyInvite.token isEqualToString:key])
             {
-                [sortedInvitedParticipants removeObjectAtIndex:index];
+                [invitedParticipants removeObjectAtIndex:index];
                 return;
             }
         }
@@ -503,15 +496,8 @@
     };
     
     // Sort each participants list in alphabetical order
-    [sortedParticipants sortUsingComparator:comparator];
-    [sortedInvitedParticipants sortUsingComparator:comparator];
-    
-    // Report sorted lists in the displayed participants list
-    actualParticipants = [NSMutableArray array];
-    [actualParticipants addObjectsFromArray:sortedParticipants];
-    
-    invitedParticipants = [NSMutableArray array];
-    [invitedParticipants addObjectsFromArray:sortedInvitedParticipants];
+    [actualParticipants sortUsingComparator:comparator];
+    [invitedParticipants sortUsingComparator:comparator];
     
     // Refer all used contacts in only one dictionary.
     contactsById = [NSMutableDictionary dictionary];

--- a/Vector/ViewController/RoomParticipantsViewController.m
+++ b/Vector/ViewController/RoomParticipantsViewController.m
@@ -464,7 +464,7 @@
             return NSOrderedDescending;
         }
 
-        if (userA.isCurrentlyActive && userB.isCurrentlyActive)
+        if (userA.currentlyActive && userB.currentlyActive)
         {
             // Order first by power levels (admins then moderators then others)
             MXRoomPowerLevels *powerLevels = [self.mxRoom.state powerLevels];
@@ -495,11 +495,11 @@
 
         }
 
-        if (userA.isCurrentlyActive && !userB.isCurrentlyActive)
+        if (userA.currentlyActive && !userB.currentlyActive)
         {
             return NSOrderedAscending;
         }
-        if (!userA.isCurrentlyActive && userB.isCurrentlyActive)
+        if (!userA.currentlyActive && userB.currentlyActive)
         {
             return NSOrderedDescending;
         }

--- a/Vector/Views/Contact/ContactTableViewCell.m
+++ b/Vector/Views/Contact/ContactTableViewCell.m
@@ -21,6 +21,7 @@
 #import "VectorDesignValues.h"
 
 #import "AvatarGenerator.h"
+#import "Tools.h"
 
 #import "MXKContactManager.h"
 
@@ -194,7 +195,7 @@
 
 - (void)refreshContactPresence
 {
-    NSString* presenceText = nil;
+    NSString* presenceText;
     NSString* matrixId = [self getFirstMatrixId];
     
     if (matrixId)
@@ -212,36 +213,7 @@
             }
         }
 
-        if (user)
-        {
-            if (user.presence == MXPresenceOnline)
-            {
-                presenceText  = NSLocalizedStringFromTable(@"room_participants_active", @"Vector", nil);
-            }
-            else
-            {
-                NSUInteger lastActiveMs = user.lastActiveAgo;
-                
-                if (-1 != lastActiveMs)
-                {
-                    NSUInteger lastActivehour = lastActiveMs / 1000 / 60 / 60;
-                    NSUInteger lastActiveDays = lastActivehour / 24;
-                    
-                    if (lastActivehour < 1)
-                    {
-                        presenceText = NSLocalizedStringFromTable(@"room_participants_active_less_1_hour", @"Vector", nil);
-                    }
-                    else if (lastActivehour < 24)
-                    {
-                        presenceText = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_participants_active_less_x_hours", @"Vector", nil), lastActivehour];
-                    }
-                    else
-                    {
-                        presenceText = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_participants_active_less_x_days", @"Vector", nil), lastActiveDays];
-                    }
-                }
-            }
-        }
+        presenceText = [Tools presenceText:user];
     }
     else if (contact.isThirdPartyInvite)
     {


### PR DESCRIPTION
Changes:
 - Members are sorted with the same algo as Vector web
 - Use currently_active information 
 - Remove (admin)

Note: Users presences are true only after logging in or resetting the cache. The issue is due to this lack in Matrix CS API: [Need a way to get all online users presences] (https://matrix.org/jira/browse/SPEC-397).