### PR TITLE
Manage www.vector.im urls as universal links

### DIFF
--- a/Vector/AppDelegate.h
+++ b/Vector/AppDelegate.h
@@ -86,15 +86,6 @@
 // Reopen an existing private OneToOne room with this userId or creates a new one (if it doesn't exist)
 - (void)startPrivateOneToOneRoomWithUserId:(NSString*)userId completion:(void (^)(void))completion;
 
-#pragma mark - Universal link
-
-/**
- Detect if a URL is a universal link for the application.
- 
- @return YES if the URL can be handled by the app.
- */
-- (BOOL)isUniversalLink:(NSURL*)url;
-
 /**
  Process the fragment part of a vector.im link.
  
@@ -102,18 +93,6 @@
  @return YES in case of processing success.
  */
 - (BOOL)handleUniversalLinkFragment:(NSString*)fragment;
-
-/**
- Fix a http://vector.im path url.
- 
- This method fixes the issue with iOS which handles URL badly when there are several hash
- keys ('%23') in the link.
- Vector.im links have often several hash keys...
-
- @param url a NSURL with possibly several hash keys and thus badly parsed.
- @return a NSURL correctly parsed.
- */
-+ (NSURL*)fixURLWithSeveralHashKeys:(NSURL*)url;
 
 @end
 

--- a/Vector/AppDelegate.m
+++ b/Vector/AppDelegate.m
@@ -30,6 +30,8 @@
 #import "NSBundle+MatrixKit.h"
 #import "MatrixSDK/MatrixSDK.h"
 
+#import "Tools.h"
+
 #import "AFNetworkReachabilityManager.h"
 
 #import <AudioToolbox/AudioToolbox.h>
@@ -731,26 +733,13 @@
 
 #pragma mark - Universal link
 
-- (BOOL)isUniversalLink:(NSURL*)url
-{
-    BOOL isUniversalLink;
-
-    if ([url.host isEqualToString:@"vector.im"]
-        && NSNotFound != [@[@"/app", @"/staging", @"/beta", @"/develop"] indexOfObject:url.path])
-    {
-        isUniversalLink = YES;
-    }
-
-    return isUniversalLink;
-}
-
 - (BOOL)handleUniversalLink:(NSUserActivity*)userActivity
 {
     NSURL *webURL = userActivity.webpageURL;
     NSLog(@"[AppDelegate] handleUniversalLink: %@", webURL.absoluteString);
 
     // iOS Patch: fix vector.im urls before using it
-    webURL = [AppDelegate fixURLWithSeveralHashKeys:webURL];
+    webURL = [Tools fixURLWithSeveralHashKeys:webURL];
 
     // Manage email validation link
     if ([webURL.path isEqualToString:@"/_matrix/identity/api/v1/validate/email/submitToken"])
@@ -1049,26 +1038,6 @@
 
     *outPathParams = pathParams;
     *outQueryParams = queryParams;
-}
-
-+ (NSURL *)fixURLWithSeveralHashKeys:(NSURL *)url
-{
-    NSURL *fixedURL = url;
-
-    // The NSURL may have no fragment because it contains more that '%23' occurence
-    if (!url.fragment)
-    {
-        // Replacing the first '%23' occurence into a '#' makes NSURL works correctly
-        NSString *urlString = url.absoluteString;
-        NSRange range = [urlString rangeOfString:@"%23"];
-        if (NSNotFound != range.location)
-        {
-            urlString = [urlString stringByReplacingCharactersInRange:range withString:@"#"];
-            fixedURL = [NSURL URLWithString:urlString];
-        }
-    }
-
-    return fixedURL;
 }
 
 #pragma mark - Matrix sessions handling

--- a/Vector/Utils/Tools.h
+++ b/Vector/Utils/Tools.h
@@ -28,4 +28,26 @@
  */
 + (NSString*)presenceText:(MXUser*)user;
 
+
+#pragma mark - Universal link
+
+/**
+ Detect if a URL is a universal link for the application.
+
+ @return YES if the URL can be handled by the app.
+ */
++ (BOOL)isUniversalLink:(NSURL*)url;
+
+/**
+ Fix a http://vector.im path url.
+
+ This method fixes the issue with iOS which handles URL badly when there are several hash
+ keys ('%23') in the link.
+ Vector.im links have often several hash keys...
+
+ @param url a NSURL with possibly several hash keys and thus badly parsed.
+ @return a NSURL correctly parsed.
+ */
++ (NSURL*)fixURLWithSeveralHashKeys:(NSURL*)url;
+
 @end

--- a/Vector/Utils/Tools.m
+++ b/Vector/Utils/Tools.m
@@ -59,4 +59,44 @@
     return presenceText;
 }
 
+#pragma mark - Universal link
+
++ (BOOL)isUniversalLink:(NSURL*)url
+{
+    BOOL isUniversalLink;
+
+    if ([url.host isEqualToString:@"vector.im"] || [url.host isEqualToString:@"www.vector.im"])
+    {
+        // iOS Patch: fix vector.im urls before using it
+        url = [Tools fixURLWithSeveralHashKeys:url];
+
+        if (NSNotFound != [@[@"/app", @"/staging", @"/beta", @"/develop"] indexOfObject:url.path])
+        {
+            isUniversalLink = YES;
+        }
+    }
+
+    return isUniversalLink;
+}
+
++ (NSURL *)fixURLWithSeveralHashKeys:(NSURL *)url
+{
+    NSURL *fixedURL = url;
+
+    // The NSURL may have no fragment because it contains more that '%23' occurence
+    if (!url.fragment)
+    {
+        // Replacing the first '%23' occurence into a '#' makes NSURL works correctly
+        NSString *urlString = url.absoluteString;
+        NSRange range = [urlString rangeOfString:@"%23"];
+        if (NSNotFound != range.location)
+        {
+            urlString = [urlString stringByReplacingCharactersInRange:range withString:@"#"];
+            fixedURL = [NSURL URLWithString:urlString];
+        }
+    }
+
+    return fixedURL;
+}
+
 @end

--- a/Vector/Vector.entitlements
+++ b/Vector/Vector.entitlements
@@ -4,6 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>applinks:www.vector.im</string>
 		<string>applinks:vector.im</string>
 	</array>
 </dict>

--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -60,6 +60,7 @@
 #import "MXKRoomBubbleTableViewCell+Vector.h"
 
 #import "AvatarGenerator.h"
+#import "Tools.h"
 
 #import "VectorDesignValues.h"
 
@@ -1374,18 +1375,15 @@
         // Try to catch universal link supported by the app
         NSURL *url = userInfo[kMXKRoomBubbleCellUrl];
 
-        // iOS Patch: fix vector.im urls before using it
-        if ([url.host isEqualToString:@"vector.im"])
+        // If the link can be open it by the app, let it do
+        if ([Tools isUniversalLink:url])
         {
-            url = [AppDelegate fixURLWithSeveralHashKeys:url];
+            shouldDoAction = NO;
 
-            // If the link can be open it by the app, let it do
-            if ([[AppDelegate theDelegate] isUniversalLink:url])
-            {
-                shouldDoAction = NO;
+            // iOS Patch: fix vector.im urls before using it
+            url = [Tools fixURLWithSeveralHashKeys:url];
 
-                [[AppDelegate theDelegate] handleUniversalLinkFragment:url.fragment];
-            }
+            [[AppDelegate theDelegate] handleUniversalLinkFragment:url.fragment];
         }
     }
 


### PR DESCRIPTION
isUniversalLink and fixURLWithSeveralHashKeys methods have been moved from AppDelegate to  new Tools class.
This is Tools and only it that contains hardcoded "vector.im" and "www.vector.im" strings