### PR TITLE
Authentication: Update the default login flow to the vector.im HS.

### DIFF
--- a/Vector/Vector-Defaults.plist
+++ b/Vector/Vector-Defaults.plist
@@ -11,7 +11,7 @@
 	<key>identityserverurl</key>
 	<string>https://vector.im</string>
 	<key>homeserverurl</key>
-	<string>https://matrix.org</string>
+	<string>https://vector.im</string>
 	<key>homeserver</key>
 	<string>matrix.org</string>
 	<key>webAppUrlDev</key>


### PR DESCRIPTION
Support automatic fallback to matrix.org HS for existing users.