### PR TITLE
Improved images & videos sending failure UX

### DIFF
--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -1066,15 +1066,8 @@
             }
             else if (tappedEvent)
             {
-                if (tappedEvent.mxkState != MXKEventStateSendingFailed)
-                {
-                    // Highlight this event in displayed message
-                    customizedRoomDataSource.selectedEventId = tappedEvent.eventId;
-                }
-                else
-                {
-                    [self dataSource:dataSource didRecognizeAction:kMXKRoomBubbleCellVectorEditButtonPressed inCell:cell userInfo:userInfo];
-                }
+                // Highlight this event in displayed message
+                customizedRoomDataSource.selectedEventId = tappedEvent.eventId;
             }
             
             // Force table refresh
@@ -1455,6 +1448,7 @@
         else if ([actionIdentifier isEqualToString:kMXKRoomBubbleCellTapOnAttachmentView]
                  && ((MXKRoomBubbleTableViewCell*)cell).bubbleData.attachment.event.mxkState == MXKEventStateSendingFailed)
         {
+            // Shortcut: when clicking on an unsent media, show the action sheet to resend it
             [self dataSource:dataSource didRecognizeAction:kMXKRoomBubbleCellVectorEditButtonPressed inCell:cell userInfo:@{kMXKRoomBubbleCellEventKey:((MXKRoomBubbleTableViewCell*)cell).bubbleData.attachment.event}];
         }
         else

--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -1066,8 +1066,15 @@
             }
             else if (tappedEvent)
             {
-                // Highlight this event in displayed message
-                customizedRoomDataSource.selectedEventId = tappedEvent.eventId;
+                if (tappedEvent.mxkState != MXKEventStateSendingFailed)
+                {
+                    // Highlight this event in displayed message
+                    customizedRoomDataSource.selectedEventId = tappedEvent.eventId;
+                }
+                else
+                {
+                    [self dataSource:dataSource didRecognizeAction:kMXKRoomBubbleCellVectorEditButtonPressed inCell:cell userInfo:userInfo];
+                }
             }
             
             // Force table refresh
@@ -1444,6 +1451,11 @@
                     currentAlert = nil;
                 }
             }
+        }
+        else if ([actionIdentifier isEqualToString:kMXKRoomBubbleCellTapOnAttachmentView]
+                 && ((MXKRoomBubbleTableViewCell*)cell).bubbleData.attachment.event.mxkState == MXKEventStateSendingFailed)
+        {
+            [self dataSource:dataSource didRecognizeAction:kMXKRoomBubbleCellVectorEditButtonPressed inCell:cell userInfo:@{kMXKRoomBubbleCellEventKey:((MXKRoomBubbleTableViewCell*)cell).bubbleData.attachment.event}];
         }
         else
         {

--- a/Vector/Views/RoomBubbleList/RoomOutgoingAttachmentBubbleCell.h
+++ b/Vector/Views/RoomBubbleList/RoomOutgoingAttachmentBubbleCell.h
@@ -21,4 +21,16 @@
  */
 @interface RoomOutgoingAttachmentBubbleCell : MXKRoomOutgoingAttachmentBubbleCell
 
+/**
+ Render specifically outgoing attachment.
+
+ There is no multi-inheritance here and some Vector RoomOutgoingAttachmentBubbleCell* classes
+ do not inherit from this class but from MXKRoomOutgoingAttachmentBubbleCell directly.
+ So, they have to call this method in their `render` method implementation.
+
+ @param cellData the data object to render.
+ @param bubbleCell the RoomOutgoingAttachmentBubbleCell cell to render to.
+ */
++ (void)render:(MXKCellData *)cellData inBubbleCell:(MXKRoomOutgoingAttachmentBubbleCell*)bubbleCell;
+
 @end

--- a/Vector/Views/RoomBubbleList/RoomOutgoingAttachmentBubbleCell.m
+++ b/Vector/Views/RoomBubbleList/RoomOutgoingAttachmentBubbleCell.m
@@ -31,11 +31,30 @@
 - (void)render:(MXKCellData *)cellData
 {
     [super render:cellData];
+
+    [RoomOutgoingAttachmentBubbleCell render:cellData inBubbleCell:self];
 }
 
 - (void)didEndDisplay
 {
     [super didEndDisplay];
+}
+
++ (void)render:(MXKCellData *)cellData inBubbleCell:(MXKRoomOutgoingAttachmentBubbleCell *)bubbleCell
+{
+    if (bubbleCell.attachmentView && bubbleCell->bubbleData.isAttachmentWithThumbnail)
+    {
+        // Show a red border when the attachment sending failed
+        if (bubbleCell->bubbleData.attachment.event.mxkState == MXKEventStateSendingFailed)
+        {
+            bubbleCell.attachmentView.layer.borderColor = kVectorTextColorRed.CGColor;
+            bubbleCell.attachmentView.layer.borderWidth = 1;
+        }
+        else
+        {
+            bubbleCell.attachmentView.layer.borderWidth = 0;
+        }
+    }
 }
 
 @end

--- a/Vector/Views/RoomBubbleList/RoomOutgoingAttachmentWithoutSenderInfoBubbleCell.h
+++ b/Vector/Views/RoomBubbleList/RoomOutgoingAttachmentWithoutSenderInfoBubbleCell.h
@@ -15,6 +15,7 @@
  */
 
 #import "MXKRoomOutgoingAttachmentWithoutSenderInfoBubbleCell.h"
+#import "RoomOutgoingAttachmentBubbleCell.h"
 
 /**
  `RoomOutgoingAttachmentWithoutSenderInfoBubbleCell` displays outgoing attachment with thumbnail, without user's name.

--- a/Vector/Views/RoomBubbleList/RoomOutgoingAttachmentWithoutSenderInfoBubbleCell.m
+++ b/Vector/Views/RoomBubbleList/RoomOutgoingAttachmentWithoutSenderInfoBubbleCell.m
@@ -24,4 +24,11 @@
     self.readReceiptsAlignment = ReadReceiptAlignmentRight;
 }
 
+- (void)render:(MXKCellData *)cellData
+{
+    [super render:cellData];
+
+    [RoomOutgoingAttachmentBubbleCell render:cellData inBubbleCell:self];
+}
+
 @end


### PR DESCRIPTION
#313 

This is done by showing a red-pink frame around the unsent media. Clicking on it display the action sheet to be able to resend it quickly.
