### PR TITLE
BugFix Can't view MemberInfo when inviting users without actually inv…

### DIFF
--- a/Vector/Assets/en.lproj/Vector.strings
+++ b/Vector/Assets/en.lproj/Vector.strings
@@ -27,6 +27,7 @@
 "create" = "Create";
 "leave" = "Leave";
 "remove" = "Remove";
+"invite" = "Invite";
 "retry" = "Retry";
 "on" = "On";
 "off" = "Off";
@@ -119,6 +120,8 @@
 "room_participants_leave_prompt_msg" = "Are you sure you want to leave this chat?";
 "room_participants_remove_prompt_title" = "Remove?";
 "room_participants_remove_prompt_msg" = "Are you sure you want to remove %@ from this chat?";
+"room_participants_invite_prompt_title" = "Invite?";
+"room_participants_invite_prompt_msg" = "Are you sure you want to invite %@ to this chat?";
 "room_participants_invite_another_user" = "Search / invite by name, email, id";
 "room_participants_invite_malformed_id_title" = "Invite Error";
 "room_participants_invite_malformed_id" = "Malformed ID. Should be an email address or a Matrix ID like '@localpart:domain'";

--- a/Vector/ViewController/ContactDetailsViewController.h
+++ b/Vector/ViewController/ContactDetailsViewController.h
@@ -53,5 +53,21 @@ typedef enum : NSUInteger
  */
 @property (nonatomic) BOOL enableVoipCall;
 
+/**
+ Returns the `UINib` object initialized for a `ContactDetailsViewController`.
+ 
+ @return The initialized `UINib` object or `nil` if there were errors during initialization
+ or the nib file could not be located.
+ */
++ (UINib *)nib;
+
+/**
+ Creates and returns a new `ContactDetailsViewController` object.
+ 
+ @discussion This is the designated initializer for programmatic instantiation.
+ @return An initialized `ContactDetailsViewController` object if successful, `nil` otherwise.
+ */
++ (instancetype)contactDetailsViewController;
+
 @end
 

--- a/Vector/ViewController/ContactDetailsViewController.m
+++ b/Vector/ViewController/ContactDetailsViewController.m
@@ -273,6 +273,17 @@
     [self refreshContactDetails];
 }
 
+- (void)setEnableVoipCall:(BOOL)enableVoipCall
+{
+    if (_enableVoipCall != enableVoipCall)
+    {
+        _enableVoipCall = enableVoipCall;
+        
+        // Refresh displayed options
+        [self.tableView reloadData];
+    }
+}
+
 #pragma mark -
 
 - (void)registerOnContactChangeNotifications
@@ -338,6 +349,8 @@
     [self refreshContactDisplayName];
     [self refreshContactPresence];
     [self refreshContactThumbnail];
+    
+    [self.tableView reloadData];
 }
 
 - (NSString*)firstMatrixId
@@ -618,7 +631,7 @@
                     
                     // Add the user to the blacklist: ignored users
                     [strongSelf addPendingActionMask];
-                    [strongSelf.mainSession ignoreUsers:@[[strongSelf firstMatrixId]]
+                    [strongSelf.mainSession ignoreUsers:@[strongSelf.firstMatrixId]
                                                 success:^{
                                                     
                                                     [strongSelf removePendingActionMask];
@@ -626,7 +639,7 @@
                                                 } failure:^(NSError *error) {
                                                     
                                                     [strongSelf removePendingActionMask];
-                                                    NSLog(@"[ContactDetailsViewController] Ignore %@ failed: %@", [strongSelf firstMatrixId], error);
+                                                    NSLog(@"[ContactDetailsViewController] Ignore %@ failed: %@", strongSelf.firstMatrixId, error);
                                                     
                                                     // Notify MatrixKit user
                                                     [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];


### PR DESCRIPTION
…iting them

https://github.com/vector-im/vector-ios/issues/271

Open contact details is not relevant here, we add the matrix id (if any) in the invitable contact display name. This change provides the missing member info.
+ Prompt user before inviting someone