### PR TITLE
Redacting membership events should immediately reset the displayname …

### DIFF
--- a/Vector/AppDelegate.m
+++ b/Vector/AppDelegate.m
@@ -1361,6 +1361,15 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 
     }];
     
+    [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionDidCorruptDataNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull notif) {
+        
+        NSLog(@"[AppDelegate] kMXSessionDidCorruptDataNotification received. Reload the app");
+        
+        // Reload entirely the app when a session has corrupted its data
+        [[AppDelegate theDelegate] reloadMatrixSessions:YES];
+        
+    }];
+    
     // Observe settings changes
     [[MXKAppSettings standardAppSettings]  addObserver:self forKeyPath:@"showAllEventsInRoomHistory" options:0 context:nil];
     

--- a/Vector/ViewController/RoomParticipantsViewController.m
+++ b/Vector/ViewController/RoomParticipantsViewController.m
@@ -59,8 +59,8 @@
     // Observe kMXSessionWillLeaveRoomNotification to be notified if the user leaves the current room.
     id leaveRoomNotificationObserver;
     
-    // Observe kMXRoomDidFlushMessagesNotification to take into account the updated room members when the room history is flushed.
-    id roomDidFlushMessagesNotificationObserver;
+    // Observe kMXRoomDidFlushDataNotification to take into account the updated room members when the room history is flushed.
+    id roomDidFlushDataNotificationObserver;
 
     RoomMemberDetailsViewController *memberDetailsViewController;
     
@@ -154,10 +154,10 @@
         leaveRoomNotificationObserver = nil;
     }
     
-    if (roomDidFlushMessagesNotificationObserver)
+    if (roomDidFlushDataNotificationObserver)
     {
-        [[NSNotificationCenter defaultCenter] removeObserver:roomDidFlushMessagesNotificationObserver];
-        roomDidFlushMessagesNotificationObserver = nil;
+        [[NSNotificationCenter defaultCenter] removeObserver:roomDidFlushDataNotificationObserver];
+        roomDidFlushDataNotificationObserver = nil;
     }
     
     if (membersListener)
@@ -266,10 +266,10 @@
         [[NSNotificationCenter defaultCenter] removeObserver:leaveRoomNotificationObserver];
         leaveRoomNotificationObserver = nil;
     }
-    if (roomDidFlushMessagesNotificationObserver)
+    if (roomDidFlushDataNotificationObserver)
     {
-        [[NSNotificationCenter defaultCenter] removeObserver:roomDidFlushMessagesNotificationObserver];
-        roomDidFlushMessagesNotificationObserver = nil;
+        [[NSNotificationCenter defaultCenter] removeObserver:roomDidFlushDataNotificationObserver];
+        roomDidFlushDataNotificationObserver = nil;
     }
     if (membersListener)
     {
@@ -300,7 +300,7 @@
         }];
         
         // Observe room history flush (sync with limited timeline, or state event redaction)
-        roomDidFlushMessagesNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXRoomDidFlushMessagesNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        roomDidFlushDataNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXRoomDidFlushDataNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
             
             MXRoom *room = notif.object;
             if (_mxRoom.mxSession == room.mxSession && [_mxRoom.state.roomId isEqualToString:room.state.roomId])


### PR DESCRIPTION
…& avatar of room members.

vector-im/vector-ios#443

Refresh Room members list on state event redaction