### PR TITLE
Unable to join federated rooms #572

### DIFF
--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -2374,9 +2374,9 @@
             
             // We promote here join by room alias instead of room id when an alias is available.
             NSString *roomIdOrAlias = roomPreviewData.roomId;
-            if (roomPreviewData.roomDataSource.room.state.aliases.count)
+            if (roomPreviewData.roomAliases.count)
             {
-                roomIdOrAlias = roomPreviewData.roomDataSource.room.state.aliases.firstObject;
+                roomIdOrAlias = roomPreviewData.roomAliases.firstObject;
             }
             
             // Note in case of simple link to a room the signUrl param is nil


### PR DESCRIPTION
Use the roomAliases field of RoomPreviewData. It contains either the aliases provided by MXPublicRoom or the aliases in the state of a room we are peeking in.