### PR TITLE
Make VoIP features enabled by default

### DIFF
--- a/Vector/Assets/en.lproj/Vector.strings
+++ b/Vector/Assets/en.lproj/Vector.strings
@@ -252,7 +252,6 @@
 "settings_fail_to_update_password" = "Fail to update password";
 "settings_password_updated" = "Your password has been updated";
 
-"settings_labs_outgoing_voip" = "Placing VoIP/Video calls";
 "settings_labs_conference_call" = "Conference Call";
 "settings_labs_conference_call_warning" = "Conference calling in Vector is in development and may not be reliable";
 

--- a/Vector/Assets/en.lproj/Vector.strings
+++ b/Vector/Assets/en.lproj/Vector.strings
@@ -252,9 +252,6 @@
 "settings_fail_to_update_password" = "Fail to update password";
 "settings_password_updated" = "Your password has been updated";
 
-"settings_labs_conference_call" = "Conference Call";
-"settings_labs_conference_call_warning" = "Conference calling in Vector is in development and may not be reliable";
-
 // Room Details
 "room_details_title" = "Room Details";
 "room_details_people" = "Members";

--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -912,9 +912,8 @@
         
         // Check whether the call option is supported
         roomInputToolbarView.supportCallOption =
-        self.roomDataSource.mxSession.callManager != nil
-        && (self.roomDataSource.room.state.joinedMembers.count == 2
-            || ([[NSUserDefaults standardUserDefaults] boolForKey:@"labsEnableConferenceCall"] && self.roomDataSource.room.state.joinedMembers.count > 2));
+        self.roomDataSource.mxSession.callManager
+        && self.roomDataSource.room.state.joinedMembers.count >= 2;
 
         // Set user picture in input toolbar
         MXKImageView *userPictureView = roomInputToolbarView.pictureView;
@@ -2643,8 +2642,7 @@
         {
             [roomActivitiesView displayNetworkErrorNotification:NSLocalizedStringFromTable(@"room_offline_notification", @"Vector", nil)];
         }
-        else if ([[NSUserDefaults standardUserDefaults] boolForKey:@"labsEnableConferenceCall"]
-                 && customizedRoomDataSource.room.state.isOngoingConferenceCall)
+        else if (customizedRoomDataSource.room.state.isOngoingConferenceCall)
         {
             // Show the "Ongoing conference call" banner only if the user is not in the conference
             MXCall *callInRoom = [self.roomDataSource.mxSession.callManager callInRoom:self.roomDataSource.roomId];

--- a/Vector/ViewController/RoomViewController.m
+++ b/Vector/ViewController/RoomViewController.m
@@ -912,8 +912,7 @@
         
         // Check whether the call option is supported
         roomInputToolbarView.supportCallOption =
-        [[NSUserDefaults standardUserDefaults] boolForKey:@"labsEnableOutgoingVoIP"]
-        && self.roomDataSource.mxSession.callManager != nil
+        self.roomDataSource.mxSession.callManager != nil
         && (self.roomDataSource.room.state.joinedMembers.count == 2
             || ([[NSUserDefaults standardUserDefaults] boolForKey:@"labsEnableConferenceCall"] && self.roomDataSource.room.state.joinedMembers.count > 2));
 

--- a/Vector/ViewController/SettingsViewController.m
+++ b/Vector/ViewController/SettingsViewController.m
@@ -55,9 +55,8 @@
 #define OTHER_CLEAR_CACHE_INDEX      6
 #define OTHER_COUNT                  7
 
-#define LABS_VOIP_INDEX                 0
-#define LABS_CONFERENCE_CALL_INDEX      1
-#define LABS_COUNT                      2
+#define LABS_CONFERENCE_CALL_INDEX      0
+#define LABS_COUNT                      1
 
 #define SECTION_TITLE_PADDING_WHEN_HIDDEN 0.01f
 
@@ -1008,35 +1007,15 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
     }
     else if (section == SETTINGS_SECTION_LABS_INDEX)
     {
-        if (row == LABS_VOIP_INDEX)
-        {
-            MXKTableViewCellWithLabelAndSwitch* labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
-
-            labelAndSwitchCell.mxkLabel.text = NSLocalizedStringFromTable(@"settings_labs_outgoing_voip", @"Vector", nil);
-            labelAndSwitchCell.mxkSwitch.on = [[NSUserDefaults standardUserDefaults] boolForKey:@"labsEnableOutgoingVoIP"];
-            [labelAndSwitchCell.mxkSwitch removeTarget:self action:nil forControlEvents:UIControlEventTouchUpInside];
-            [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleLabsVoIP:) forControlEvents:UIControlEventTouchUpInside];
-
-            cell = labelAndSwitchCell;
-        }
-        else if (row == LABS_CONFERENCE_CALL_INDEX)
+        if (row == LABS_CONFERENCE_CALL_INDEX)
         {
             MXKTableViewCellWithLabelAndSwitch* labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
 
             labelAndSwitchCell.mxkLabel.text = NSLocalizedStringFromTable(@"settings_labs_conference_call", @"Vector", nil);
             labelAndSwitchCell.mxkSwitch.on = [[NSUserDefaults standardUserDefaults] boolForKey:@"labsEnableConferenceCall"];
 
-            // VoIP must be enabled on order to change this settings
-            if ([[NSUserDefaults standardUserDefaults] boolForKey:@"labsEnableOutgoingVoIP"])
-            {
-                [labelAndSwitchCell.mxkSwitch removeTarget:self action:nil forControlEvents:UIControlEventTouchUpInside];
-                [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleLabsConferenceCall:) forControlEvents:UIControlEventTouchUpInside];
-            }
-            else
-            {
-                labelAndSwitchCell.mxkLabel.enabled = NO;
-                labelAndSwitchCell.mxkSwitch.enabled = NO;
-            }
+            [labelAndSwitchCell.mxkSwitch removeTarget:self action:nil forControlEvents:UIControlEventTouchUpInside];
+            [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleLabsConferenceCall:) forControlEvents:UIControlEventTouchUpInside];
 
             cell = labelAndSwitchCell;
         }
@@ -1334,20 +1313,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
         
         [[AppDelegate theDelegate] startGoogleAnalytics];
     }
-}
-
-- (void)toggleLabsVoIP:(id)sender
-{
-    BOOL enable = [[NSUserDefaults standardUserDefaults] boolForKey:@"labsEnableOutgoingVoIP"];
-
-    NSLog(@"[SettingsViewController] %@ VoIP", enable ? @"Disable" : @"Enable");
-
-    [[NSUserDefaults standardUserDefaults] setBool:!enable forKey:@"labsEnableOutgoingVoIP"];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-
-    // Refresh the "Conference Call" button
-    [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:LABS_CONFERENCE_CALL_INDEX inSection:SETTINGS_SECTION_LABS_INDEX]]
-                          withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (void)toggleLabsConferenceCall:(id)sender

--- a/Vector/ViewController/SettingsViewController.m
+++ b/Vector/ViewController/SettingsViewController.m
@@ -34,7 +34,7 @@
 #define SETTINGS_SECTION_ADVANCED_INDEX                 4
 #define SETTINGS_SECTION_OTHER_INDEX                    5
 #define SETTINGS_SECTION_LABS_INDEX                     6
-#define SETTINGS_SECTION_COUNT                          7
+#define SETTINGS_SECTION_COUNT                          6   // Not 7 because the LABS section is currently hidden
 
 #define NOTIFICATION_SETTINGS_ENABLE_PUSH_INDEX                 0
 #define NOTIFICATION_SETTINGS_GLOBAL_SETTINGS_INDEX             1
@@ -55,8 +55,7 @@
 #define OTHER_CLEAR_CACHE_INDEX      6
 #define OTHER_COUNT                  7
 
-#define LABS_CONFERENCE_CALL_INDEX      0
-#define LABS_COUNT                      1
+#define LABS_COUNT                   0
 
 #define SECTION_TITLE_PADDING_WHEN_HIDDEN 0.01f
 
@@ -1007,18 +1006,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
     }
     else if (section == SETTINGS_SECTION_LABS_INDEX)
     {
-        if (row == LABS_CONFERENCE_CALL_INDEX)
-        {
-            MXKTableViewCellWithLabelAndSwitch* labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
-
-            labelAndSwitchCell.mxkLabel.text = NSLocalizedStringFromTable(@"settings_labs_conference_call", @"Vector", nil);
-            labelAndSwitchCell.mxkSwitch.on = [[NSUserDefaults standardUserDefaults] boolForKey:@"labsEnableConferenceCall"];
-
-            [labelAndSwitchCell.mxkSwitch removeTarget:self action:nil forControlEvents:UIControlEventTouchUpInside];
-            [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleLabsConferenceCall:) forControlEvents:UIControlEventTouchUpInside];
-
-            cell = labelAndSwitchCell;
-        }
     }
 
     return cell;
@@ -1312,65 +1299,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
         [[NSUserDefaults standardUserDefaults] synchronize];
         
         [[AppDelegate theDelegate] startGoogleAnalytics];
-    }
-}
-
-- (void)toggleLabsConferenceCall:(id)sender
-{
-    BOOL enable = [[NSUserDefaults standardUserDefaults] boolForKey:@"labsEnableConferenceCall"];
-
-    if (sender && !enable)
-    {
-        // Ask confirmation to the user before enabling it
-        UISwitch *switchButton;
-        if ([sender isKindOfClass:UISwitch.class])
-        {
-            switchButton = (UISwitch*)sender;
-
-        }
-
-        // Prevent the toggle from toggling without the user confirmation
-        [switchButton setOn:NO animated:YES];
-
-        [currentAlert dismiss:NO];
-        currentAlert = [[MXKAlert alloc] initWithTitle:NSLocalizedStringFromTable(@"warning", @"Vector", nil)
-                                               message:NSLocalizedStringFromTable(@"settings_labs_conference_call_warning", @"Vector", nil)
-                                                 style:MXKAlertStyleAlert];
-
-        __weak typeof(self) weakSelf = self;
-
-        currentAlert.cancelButtonIndex = [currentAlert addActionWithTitle:[NSBundle mxk_localizedStringForKey:@"abort"] style:MXKAlertActionStyleDefault handler:^(MXKAlert *alert) {
-
-            if (weakSelf)
-            {
-                __strong __typeof(weakSelf)strongSelf = weakSelf;
-                strongSelf->currentAlert = nil;
-            }
-        }];
-
-        [currentAlert addActionWithTitle:[NSBundle mxk_localizedStringForKey:@"ok"]  style:MXKAlertActionStyleDefault handler:^(MXKAlert *alert) {
-
-            if (weakSelf)
-            {
-                __strong __typeof(weakSelf)strongSelf = weakSelf;
-                strongSelf->currentAlert = nil;
-
-                // Apply the change
-                [switchButton setOn:YES animated:YES];
-                [strongSelf toggleLabsConferenceCall:nil];
-            }
-        }];
-
-        [currentAlert showInViewController:self];
-
-
-    }
-    else
-    {
-        NSLog(@"[SettingsViewController] %@ connference call", enable ? @"Disable" : @"Enable");
-
-        [[NSUserDefaults standardUserDefaults] setBool:!enable forKey:@"labsEnableConferenceCall"];
-        [[NSUserDefaults standardUserDefaults] synchronize];
     }
 }
 


### PR DESCRIPTION
This PR removes the following options from Settings > LABS:
- "Placing VoIP/Video calls" 
- "Conference Call"

The LABS section is now hidden because it is empty but the code to manage this section remains because there are new dangerous features to come.