### PR TITLE
Until e2e is impl'd, encrypted msgs should be shown in the UI as unencryptable warning text 

### DIFF
--- a/Vector/Utils/EventFormatter.m
+++ b/Vector/Utils/EventFormatter.m
@@ -64,6 +64,7 @@
         }
         self.stateEventTextFont = [UIFont italicSystemFontOfSize:15];
         self.callNoticesTextFont = [UIFont italicSystemFontOfSize:15];
+        self.encryptedMessagesTextFont = [UIFont italicSystemFontOfSize:15];
     }
     return self;
 }


### PR DESCRIPTION
#559