### PR TITLE
Messages - Room notification modes.

### DIFF
--- a/Vector/Categories/MXRoom+Vector.h
+++ b/Vector/Categories/MXRoom+Vector.h
@@ -27,9 +27,14 @@
 @property(nonatomic, readonly) NSString* vectorDisplayname;
 
 /**
- Tell whether the notifications are disabled for the room.
+ Tell whether all the notifications are disabled for the room.
  */
 @property(nonatomic, readonly, getter=isMute) BOOL mute;
+
+/**
+ Tell whether the regular notifications are disabled for the room.
+ */
+@property(nonatomic, readonly, getter=isMentionsOnly) BOOL mentionsOnly;
 
 /*
  Observer when a rules deletion fails.
@@ -62,12 +67,27 @@
 - (void)setRoomTag:(NSString*)tag completion:(void (^)())completion;
 
 /**
- Enable/disable room notifications.
+ Disable all the room notifications.
  
- @param mute YES to disable room notification
  @param completion the block to execute at the end of the operation (independently if it succeeded or not).
  You may specify nil for this parameter.
  */
-- (void)setMute:(BOOL)mute completion:(void (^)())completion;
+- (void)mute:(void (^)())completion;
+
+/**
+ Set the room notifications in mention only mode.
+ 
+ @param completion the block to execute at the end of the operation (independently if it succeeded or not).
+ You may specify nil for this parameter.
+ */
+- (void)mentionsOnly:(void (^)())completion;
+
+/**
+ Enable the room notifications.
+ 
+ @param completion the block to execute at the end of the operation (independently if it succeeded or not).
+ You may specify nil for this parameter.
+ */
+- (void)allMessages:(void (^)())completion;
 
 @end

--- a/Vector/ViewController/RecentsViewController.m
+++ b/Vector/ViewController/RecentsViewController.m
@@ -407,7 +407,7 @@
         NSString* title = @"      ";
         
         // Notification toggle
-        BOOL isMuted = room.isMute;
+        BOOL isMuted = room.isMute || room.isMentionsOnly;
         
         UITableViewRowAction *muteAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal title:title handler:^(UITableViewRowAction *action, NSIndexPath *indexPath){
             
@@ -593,14 +593,28 @@
         {
             [self startActivityIndicator];
             
-            [room setMute:mute completion:^{
-                
-                [self stopActivityIndicator];
-                
-                // Leave editing mode
-                [self setEditing:NO];
-                
-            }];
+            if (mute)
+            {
+                [room mentionsOnly:^{
+                    
+                    [self stopActivityIndicator];
+                    
+                    // Leave editing mode
+                    [self setEditing:NO];
+                    
+                }];
+            }
+            else
+            {
+                [room allMessages:^{
+                    
+                    [self stopActivityIndicator];
+                    
+                    // Leave editing mode
+                    [self setEditing:NO];
+                    
+                }];
+            }
         }
         else
         {

--- a/Vector/ViewController/RoomSettingsViewController.m
+++ b/Vector/ViewController/RoomSettingsViewController.m
@@ -1509,18 +1509,34 @@ NSString *const kRoomSettingsAdvancedCellViewIdentifier = @"kRoomSettingsAdvance
         
         if ([updatedItemsDict objectForKey:kRoomSettingsMuteNotifKey])
         {
-            [mxRoom setMute:roomNotifSwitch.on completion:^{
-                
-                if (weakSelf)
-                {
-                    __strong __typeof(weakSelf)strongSelf = weakSelf;
+            if (roomNotifSwitch.on)
+            {
+                [mxRoom mentionsOnly:^{
                     
-                    [strongSelf->updatedItemsDict removeObjectForKey:kRoomSettingsMuteNotifKey];
-                    [strongSelf onSave:nil];
-                }
-                
-            }];
-            
+                    if (weakSelf)
+                    {
+                        __strong __typeof(weakSelf)strongSelf = weakSelf;
+                        
+                        [strongSelf->updatedItemsDict removeObjectForKey:kRoomSettingsMuteNotifKey];
+                        [strongSelf onSave:nil];
+                    }
+                    
+                }];
+            }
+            else
+            {
+                [mxRoom allMessages:^{
+                    
+                    if (weakSelf)
+                    {
+                        __strong __typeof(weakSelf)strongSelf = weakSelf;
+                        
+                        [strongSelf->updatedItemsDict removeObjectForKey:kRoomSettingsMuteNotifKey];
+                        [strongSelf onSave:nil];
+                    }
+                    
+                }];
+            }
             return;
         }
         
@@ -1798,7 +1814,7 @@ NSString *const kRoomSettingsAdvancedCellViewIdentifier = @"kRoomSettingsAdvance
             }
             else
             {
-                roomNotifSwitch.on = mxRoom.isMute;
+                roomNotifSwitch.on = mxRoom.isMute || mxRoom.isMentionsOnly;
             }
             
             cell = roomNotifCell;
@@ -2769,7 +2785,7 @@ NSString *const kRoomSettingsAdvancedCellViewIdentifier = @"kRoomSettingsAdvance
 {
     if (theSwitch == roomNotifSwitch)
     {
-        if (roomNotifSwitch.on == mxRoom.isMute)
+        if (roomNotifSwitch.on == (mxRoom.isMute || mxRoom.isMentionsOnly))
         {
             [updatedItemsDict removeObjectForKey:kRoomSettingsMuteNotifKey];
         }


### PR DESCRIPTION
The web client defines 4 levels of notifications: 'All messages (loud)', 'All messages', 'Mentions only' and 'Mute'.
The ios client support only 2 modes: Mute / Unmute.

We update the client to map these 2 modes with the 4 new ones until a new design is defined to handle the 4 levels on mobile client:
- When a room is in 'Mute' or 'Mentions only mode', it is displayed as mute. Else it is unmute.
- When the user unmute a room, the room switches in 'All message mode'.
- When the user mute a room, the room switches in 'Mentions only' mode.