### PR TITLE
Tapping notifications doesn't take you to the right room in iOS 10

### DIFF
--- a/Vector/AppDelegate.m
+++ b/Vector/AppDelegate.m
@@ -906,6 +906,18 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     completionHandler(UIBackgroundFetchResultNoData);
 }
 
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
+{
+    // iOS 10 (at least up to GM beta release) does not call application:didReceiveRemoteNotification:fetchCompletionHandler:
+    // when the user clicks on a notification but it calls this deprecated version
+    // of didReceiveRemoteNotification.
+    // Use this method as a workaround as adviced at http://stackoverflow.com/a/39419245
+    NSLog(@"[AppDelegate] didReceiveRemoteNotification (deprecated version)");
+
+    [self application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:^(UIBackgroundFetchResult result) {
+    }];
+}
+
 - (void)refreshApplicationIconBadgeNumber
 {
     NSUInteger count = [MXKRoomDataSourceManager missedDiscussionsCount];


### PR DESCRIPTION
#599
Maybe a bug in iOS 10 pre-releases. Use the workaround at http://stackoverflow.com/a/39419245 to make it work