### PR TITLE
Allow Riot to autostart when phone boots, Fixes #538

### DIFF
--- a/Vector/Info.plist
+++ b/Vector/Info.plist
@@ -43,6 +43,7 @@
 	<array>
 		<string>audio</string>
 		<string>remote-notification</string>
+		<string>voip</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>


### PR DESCRIPTION
I think this is all that is needed to fix issue #538. I can't test it because I am not a member of the Apple developer program but according to [this developer documentation](https://developer.apple.com/library/content/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/BackgroundExecution/BackgroundExecution.html), we need to add this VoIP background mode so that the app can start on boot. According to the docs: `Apps with this key are automatically launched after system boot so that the app can reestablish VoIP services.`