### PR TITLE
Converting existing rooms to/from DMs

### DIFF
--- a/Vector/AppDelegate.m
+++ b/Vector/AppDelegate.m
@@ -1878,14 +1878,13 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
         
         if (mxSession)
         {
-            NSArray *directRooms = mxSession.directRooms[userId];
-            NSString *firstDirectRoomId = directRooms.firstObject;
+            MXRoom *directRoom = [mxSession directJoinedRoomWithUserId:userId];
             
             // if the room exists
-            if (firstDirectRoomId)
+            if (directRoom)
             {
                 // open it
-                [self showRoom:firstDirectRoomId andEventId:nil withMatrixSession:mxSession];
+                [self showRoom:directRoom.roomId andEventId:nil withMatrixSession:mxSession];
                 
                 if (completion)
                 {

--- a/Vector/ViewController/ContactDetailsViewController.m
+++ b/Vector/ViewController/ContactDetailsViewController.m
@@ -935,12 +935,14 @@
                 [self addPendingActionMask];
                 
                 NSString *matrixId = self.firstMatrixId;
-                MXRoom* oneToOneRoom = [self.mainSession privateOneToOneRoomWithUserId:matrixId];
+                
+                NSString *directRoomId = self.mainSession.directRooms[matrixId].firstObject;
+                MXRoom* directRoom = [self.mainSession roomWithRoomId:directRoomId];
                 
                 // Place the call directly if the room exists
-                if (oneToOneRoom)
+                if (directRoom)
                 {
-                    [oneToOneRoom placeCallWithVideo:isVideoCall success:nil failure:nil];
+                    [directRoom placeCallWithVideo:isVideoCall success:nil failure:nil];
                     [self removePendingActionMask];
                 }
                 else

--- a/Vector/ViewController/RoomMemberDetailsViewController.m
+++ b/Vector/ViewController/RoomMemberDetailsViewController.m
@@ -53,7 +53,7 @@
     /**
      List of the direct chats (room ids) with this member.
      */
-    NSArray<NSString*> *directChatsArray;
+    NSMutableArray<NSString*> *directChatsArray;
     NSInteger directChatsIndex;
     
     /**
@@ -88,6 +88,7 @@
     
     adminActionsArray = [[NSMutableArray alloc] init];
     otherActionsArray = [[NSMutableArray alloc] init];
+    directChatsArray = [[NSMutableArray alloc] init];
     
     // Setup `MXKViewControllerHandling` properties
     self.defaultBarTintColor = kVectorNavBarTintColor;
@@ -351,7 +352,7 @@
     
     [adminActionsArray removeAllObjects];
     [otherActionsArray removeAllObjects];
-    directChatsArray = nil;
+    [directChatsArray removeAllObjects];
     
     // Consider the case of the user himself
     if ([self.mxRoomMember.userId isEqualToString:self.mainSession.myUser.userId])
@@ -487,10 +488,18 @@
     }
     
     // Retrieve the existing direct chats
-    directChatsArray = self.mainSession.directRooms[self.mxRoomMember.userId];
+    NSArray *directRoomIds = self.mainSession.directRooms[self.mxRoomMember.userId];
+    
+    // Check whether the room is still existing
+    for (NSString* directRoomId in directRoomIds)
+    {
+        if ([self.mainSession roomWithRoomId:directRoomId])
+        {
+            [directChatsArray addObject:directRoomId];
+        }
+    }
     
     adminToolsIndex = otherActionsIndex = directChatsIndex = -1;
-    
     
     if (otherActionsArray.count)
     {


### PR DESCRIPTION
#715

Apply MatrixSDK changes (matrix-org/matrix-ios-sdk#158): Remove privateOneToOneRoomWithUserId: and privateOneToOneUsers (the developer must use the directRooms property instread).