### PR TITLE
End-to-end encryption UI/UX

### DIFF
--- a/Vector/Views/RoomBubbleList/Encryption/RoomEncryptedDataBubbleCell.m
+++ b/Vector/Views/RoomBubbleList/Encryption/RoomEncryptedDataBubbleCell.m
@@ -26,7 +26,17 @@ NSString *const kRoomEncryptedDataBubbleCellTapOnEncryptionIcon = @"kRoomEncrypt
     
     if (!event.isEncrypted)
     {
-        encryptionIcon = @"e2e_unencrypted";
+        // Patch: Display the verified icon on outgoing messages in the encrypted rooms (until #773 is fixed)
+        MXRoom *room = [session roomWithRoomId:event.roomId];
+        if (room.state.isEncrypted && session.crypto && [event.sender isEqualToString:session.myUser.userId])
+        {
+            // The outgoing message are encrypted by default
+            encryptionIcon = @"e2e_verified";
+        }
+        else
+        {
+            encryptionIcon = @"e2e_unencrypted";
+        }
     }
     else if (event.decryptionError)
     {


### PR DESCRIPTION
#723

Patch: Display the verified icon on outgoing messages in the encrypted rooms (until #773 is fixed)